### PR TITLE
add Docusaurus plugin to allow symlinks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,18 @@ const config = {
   projectName: "zed", // Usually your repo name.
   trailingSlash: true,
 
+  plugins: [
+    // This plugin allows, e.g, docs/ to be a symlink to ../zed/docs/.
+    function (context, options) {
+      return {
+        name: 'allow-symlinks-plugin',
+        configureWebpack(config, isServer, utils) {
+          return { resolve: { symlinks: false } }
+        }
+      };
+    },
+  ],
+
   presets: [
     [
       "classic",


### PR DESCRIPTION
Out of the box, Docusaurus chokes on symlinks.  Add a plugin to allow
them so that docs/ can be a symlink to ../zed/docs/.