### PR TITLE
Remove deploy section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,3 @@ $ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
The deploy section isn't needed since deployment of the site is done
automatically via Github Actions.