### PR TITLE
remove broken Tutorial link from footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,15 +86,6 @@ const config = {
         style: "dark",
         links: [
           {
-            title: "Docs",
-            items: [
-              {
-                label: "Tutorial",
-                to: "/docs/intro",
-              },
-            ],
-          },
-          {
             title: "Community",
             items: [
               {


### PR DESCRIPTION
And since it's the only link in the Docs footer column, remove that too.

(Removing this feels sensible since the sidebar already provides navigation to the tutorials.)

Before:
<img width="898" alt="image" src="https://user-images.githubusercontent.com/2574448/173618589-0b157292-998c-460e-9476-cefec98c0290.png">

After:
<img width="898" alt="image" src="https://user-images.githubusercontent.com/2574448/173618707-90413187-d831-4b34-99f6-130fae747666.png">
