### PR TITLE
Use an editUrl function to fix broken "Edit this page" links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,13 +36,8 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: ({version, docPath}) => {
-            if (version === "current") {
-              return `https://github.com/brimdata/zed/edit/main/docs/${docPath}`;
-            } else {
-              return `https://github.com/brimdata/zed/tree/${version}/docs/${docPath}`;
-            }
-          },
+          editUrl: ({docPath}) =>
+            `https://github.com/brimdata/zed/edit/main/docs/${docPath}`,
           exclude: ["**/ztests/**"],
         },
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,13 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/brimdata/zed/tree/main",
+          editUrl: ({version, docPath}) => {
+            if (version === "current") {
+              return `https://github.com/brimdata/zed/edit/main/docs/${docPath}`;
+            } else {
+              return `https://github.com/brimdata/zed/tree/${version}/docs/${docPath}`;
+            }
+          },
           exclude: ["**/ztests/**"],
         },
         theme: {


### PR DESCRIPTION
#27 describes how the "Edit this page" link at the bottom of all the versioned docs pages is currently broken. This PR fixes the problem by using a function for the `editUrl` setting rather than a string, which allows us to build the URL dynamically. By taking this approach, it also improves on what was there before by actually going directly into the GitHub editor for the target page, as long as they've got the "Next" version of the docs selected from the pull-down. If they have one of the older versions selected like `v1.1.0` or `v1.2.0`, it just lands at the tagged version of the doc in the Zed repo.

You can see a working deployment of the docs site with this fix at https://philrz.github.io/.
