### PR TITLE
Remove trailing slash & plus backport link fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   stylesheets: ["https://use.typekit.net/nll6rzm.css"],
   organizationName: "brimdata",
   projectName: "zed",
-  trailingSlash: true,
+  trailingSlash: false,
 
   plugins: [
     // This plugin allows, e.g, docs/ to be a symlink to ../zed/docs/.

--- a/versioned_docs/version-v1.1.0/README.md
+++ b/versioned_docs/version-v1.1.0/README.md
@@ -47,9 +47,9 @@ across one or more [data pools](commands/zed.md#14-data-pools) with ACID commit 
 accessed via a [Git](https://git-scm.com/)-like API.
 * The [Zed language](language/README.md) is the system's dataflow language for performing
 queries, searches, analytics, transformations, or any of the above combined together.
-* A  [Zed query](language/README.md#1-introduction) is a Zed script that performs
+* A  [Zed query](language/overview.md#1-introduction) is a Zed script that performs
 search and/or analytics.
-* A [Zed shaper](language/README.md#9-shaping) is a Zed script that performs
+* A [Zed shaper](language/overview.md#9-shaping) is a Zed script that performs
 data transformation to _shape_
 the input data into the desired set of organizing Zed data types called "shapes",
 which are traditionally called _schemas_ in relational systems but are

--- a/versioned_docs/version-v1.1.0/commands/zed.md
+++ b/versioned_docs/version-v1.1.0/commands/zed.md
@@ -32,7 +32,7 @@ sidebar_label: zed
 A Zed lake is a cloud-native arrangement of data, optimized for search,
 analytics, ETL, data discovery, and data preparation
 at scale based on data represented in accordance
-with the [Zed data model](../formats).
+with the [Zed data model](../formats/zed.md).
 
 A lake is organized into a collection of data pools forming a single
 administrative domain.  The current implementation supports
@@ -52,7 +52,7 @@ A core theme of the Zed lake design is _ergonomics_.  Given the Git metaphor,
 our goal here is that the Zed lake tooling be as easy and familiar as Git is
 to a technical user.
 
-Since Zed lakes are built around the [Zed data model](../formats/zed.md),
+Since Zed lakes are built around the Zed data model,
 getting different kinds of data into and out of a lake is easy.
 There is no need to define schemas or tables and then fit
 semi-structured data into schemas before loading data into a lake.
@@ -245,7 +245,7 @@ As pool data is often comprised of Zed records (analogous to JSON objects),
 the pool key is typically a field of the stored records.
 When pool data is not structured as records/objects (e.g., scalar or arrays or other
 non-record types), then the pool key would typically be configured
-as the [special value `this`](../language/README.md#23-the-special-value-this).
+as the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 Data can be efficiently scanned via ranges of values conforming to the pool key.
 
@@ -444,7 +444,7 @@ The `-orderby` option indicates the pool key that is used to sort
 the data in lake, which may be in ascending or descending order.
 
 If a pool key is not specified, then it defaults to
-the [special value `this`](../language/README.md#23-the-special-value-this).
+the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 A newly created pool is initialized with a branch called `main`.
 

--- a/versioned_docs/version-v1.1.0/commands/zq.md
+++ b/versioned_docs/version-v1.1.0/commands/zq.md
@@ -50,7 +50,7 @@ default format when output is directed to the terminal.  ZNG is the default
 when redirecting to a non-terminal output like a file or pipe.
 
 When run with input arguments, each input's format is automatically inferred
-([as described below](#21-auto-detection)) and each input is scanned
+([as described below](#22-auto-detection)) and each input is scanned
 in the order appearing on the command line forming the input stream.
 
 A query expressed in the [Zed language](../language/README.md)
@@ -88,7 +88,7 @@ emits
 ```mdtest-output
 2
 ```
-Note here that the query `1+1` [implies](../language/README.md#26-implied-operators)
+Note here that the query `1+1` [implies](../language/overview.md#26-implied-operators)
 `yield 1+1`.
 
 ## 2. Input Formats
@@ -351,7 +351,7 @@ If you are ever stumped about how the `zq` compiler is parsing your query,
 you can always run `zq -C` to compile and display your query in canonical form
 without running it.
 This can be especially handy when you are learning the language and
-[its shortcuts](../language/README.md#26-implied-operators).
+[its shortcuts](../language/overview.md#26-implied-operators).
 
 For example, this query
 ```mdtest-command
@@ -380,7 +380,7 @@ as soon as they happen and cause the `zq` process to exit.
 On the other hand,
 runtime errors resulting from the Zed query itself
 do not halt execution.  Instead, these error conditions produce
-[first-class Zed errors](../language/README.md#53-first-class-errors)
+[first-class Zed errors](../language/overview.md#53-first-class-errors)
 in the data output stream interleaved with any valid results.
 Such errors are easily queried with the
 [is_error function](../language/functions/is_error.md).
@@ -421,7 +421,7 @@ echo <values> | zq <query> -
 which is used throughout the [language documentation](../language/README.md)
 and [operator reference](../language/operators/README.md).
 
-The language documentation and [tutorials directory](../tutorials)
+The language documentation and [tutorials directory](../tutorials/README.md)
 have many examples, but here are a few more simple `zq` use cases.
 
 _Hello, world_
@@ -529,7 +529,7 @@ for sparse results, many frames are discarded without their uncompressed bytes
 having to be processed any further.
 
 While this pre-search technique results in very fast brute-force pattern matching,
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 can also be created when Zed data is managed by a Zed lake
 thereby avoiding scans of data altogether as the index pinpoints the locations
 of specific values in the lake.
@@ -545,7 +545,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed/blob/v1.1.0/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -582,7 +582,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](../../zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.1.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install
@@ -698,7 +698,7 @@ However, the benefit of Zed is that no flattening is required.  And unlike `sqli
 performance techniques cannot be applied to the Zed model and this is precisely what the
 open-source Zed project intends to do.  As a first step, with a
 [Zed lake](zed.md), you can build type-flexible
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 to scale searches across very large stores of Zed data.
 
 Stay tuned!

--- a/versioned_docs/version-v1.1.0/formats/README.md
+++ b/versioned_docs/version-v1.1.0/formats/README.md
@@ -43,7 +43,7 @@ Instead, file formats like Avro, ORC, and Parquet arose to represent tabular dat
 with an explicit schema followed by a sequence of values that conform to the schema.
 While Avro and Parquet schemas can also represent semi-structured data, all of the
 values in a given Avro or Parquet file must conform to the same schema.
-The [Iceberg specification](https://iceberg.apache.org/#spec/)
+The [Iceberg specification](https://iceberg.apache.org/spec/)
 defines data types and metadata schemas for how large relational tables can be
 managed as a collection of Avro, ORC, and/or Parquet files.
 
@@ -275,7 +275,7 @@ embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
 the [Zealot JavaScript library](https://github.com/brimdata/zealot)
-and the [Zed Python library](../../python/zed).
+and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between
 a human-readable form, a row-based binary form, and a row-based columnar form can

--- a/versioned_docs/version-v1.1.0/install.md
+++ b/versioned_docs/version-v1.1.0/install.md
@@ -35,7 +35,7 @@ architectures in the Zed [Github Release page](https://github.com/brimdata/zed/r
 
 Each archive includes the build for `zq` and `zed`.
 
-Once installed, run a [quick test](#hello-world).
+Once installed, run a [quick test](#quick-tests).
 
 ## Building from source
 

--- a/versioned_docs/version-v1.1.0/language/README.md
+++ b/versioned_docs/version-v1.1.0/language/README.md
@@ -3,5 +3,5 @@
 The language documents:
 * provide an [overview](overview.md) of the Zed language,
 * layout some [conventions](conventions.md) for the documenation, and
-* enumerate the [operators](operators), [functions](functions),
-and [aggregate functions](aggregates) in reference format.
+* enumerate the [operators](operators/README.md), [functions](functions/README.md),
+and [aggregate functions](aggregates/README.md) in reference format.

--- a/versioned_docs/version-v1.1.0/language/aggregates/fuse.md
+++ b/versioned_docs/version-v1.1.0/language/aggregates/fuse.md
@@ -8,7 +8,7 @@ fuse(any) -> type
 ```
 ### Description
 
-The _fuse_ aggregate function applies [type fusion](../README.md#type-fusion)
+The _fuse_ aggregate function applies [type fusion](../overview.md#10-type-fusion)
 to its input and returns the fused type.
 
 This aggregation is useful with group-by for data exploration and discovery  

--- a/versioned_docs/version-v1.1.0/language/functions/grep.md
+++ b/versioned_docs/version-v1.1.0/language/functions/grep.md
@@ -12,8 +12,8 @@ grep(<pattern> [, e: any]) -> bool
 The _grep_ function searches all of the strings in its input value `e`
 (or `this` if `e` is not given)
  using the `<pattern>` argument, which must be a
-[regular expression](../README.md#regular-expressions),
-[glob pattern](../README.md#globs), or string literal.
+[regular expression](../overview.md#711-regular-expressions),
+[glob pattern](../overview.md#712-globs), or string literal.
 If the pattern matches for any string, then the result is `true`.  Otherwise, it is `false`.
 
 > Note that string matches are case insensitive while regular expression

--- a/versioned_docs/version-v1.1.0/language/functions/typename.md
+++ b/versioned_docs/version-v1.1.0/language/functions/typename.md
@@ -9,7 +9,7 @@ typename(s: string) -> type
 ```
 ### Description
 
-The _typename_ function returns the [type](../../formats/zson.md#357-type-type) of the
+The _typename_ function returns the [type](../../formats/zson.md#25-types) of the
 named type give by `name` if it exists.  Otherwise, `error("missing")` is returned.
 
 ### Examples

--- a/versioned_docs/version-v1.1.0/language/functions/typeof.md
+++ b/versioned_docs/version-v1.1.0/language/functions/typeof.md
@@ -9,7 +9,7 @@ typeof(val: any) -> type
 ```
 ### Description
 
-The _typeof_ function returns the [type](../../formats/zson.md#357-type-type) of
+The _typeof_ function returns the [type](../../formats/zson.md#25-types) of
 its argument `val`.  Types in Zed are first class so the returned type is
 also a Zed value.  The type of a type is type `type`.
 

--- a/versioned_docs/version-v1.1.0/language/operators/cut.md
+++ b/versioned_docs/version-v1.1.0/language/operators/cut.md
@@ -10,7 +10,7 @@ cut <field>[:=<expr>] [, <field>[:=<expr>] ...]
 ### Description
 
 The `cut` operator extracts values from each input record in the
-form of one or more [field assignments](../README.md#field-assignments),
+form of one or more [field assignments](../overview.md#25-field-assignments),
 creating one field for each expression.  Unlike the `put` operator,
 which adds or modifies the fields of a record, `cut` retains only the
 fields enumerated, much like a SQL projection.
@@ -34,7 +34,7 @@ resulting in `error("missing")` for expressions that reference fields of `this`.
 
 Note that when the field references are all top level,
 `cut` is a special case of a yield with a
-[record literal](../README.md#record-literal) having the form:
+[record literal](../overview.md#6112-record-expressions) having the form:
 ```
 yield {<field>:<expr> [, <field>:<expr>...]}
 ```

--- a/versioned_docs/version-v1.1.0/language/operators/put.md
+++ b/versioned_docs/version-v1.1.0/language/operators/put.md
@@ -9,7 +9,7 @@ put <field>:=<expr> [, <field>:=<expr> ...]
 ### Description
 
 The `put` operator modifies its input with
-one or more [field assignments](../README.md#field-assignments).
+one or more [field assignments](../overview.md#25-field-assignments).
 Each expression is evaluated based on the input record
 and the result is either assigned to a new field of the input record if it does not
 exist, or the existing field is modified in its original location with the result.
@@ -23,7 +23,7 @@ a computed value cannot be referenced in another expression.  If you need
 to re-use a computed result, this can be done by chaining multiple `put` operators.
 
 The "put" keyword is optional since it is an
-[implied operators](../README.md#implied-operators).
+[implied operators](../overview.md#26-implied-operators).
 
 Each `<field>` expression must be a field reference expressed as a dotted path or one more
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,
@@ -35,7 +35,7 @@ For any input value that is not a record, an error is emitted.
 
 Note that when the field references are all top level,
 `put` is a special case of a `yield` with a
-[record literal](../README.md#record-literal)
+[record literal](../overview.md#6112-record-expressions)
 using a spread operator of the form:
 ```
 yield {...this, <field>:<expr> [, <field>:<expr>...]}

--- a/versioned_docs/version-v1.1.0/language/operators/search.md
+++ b/versioned_docs/version-v1.1.0/language/operators/search.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "search" keyword may be omitted in which case `<sexpr>` follows
-the [search expression](../README.md#search-expressions) syntax.
+the [search expression](../overview.md#7-search-expressions) syntax.
 
 When Zed queries are run interactively, it is convenient to be able to omit
 the "search" keyword, but when search filters appear in Zed source files,

--- a/versioned_docs/version-v1.1.0/language/operators/where.md
+++ b/versioned_docs/version-v1.1.0/language/operators/where.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "where" keyword requires a regular Zed expression and does not support
-[search expressions](../README.md#search-expressions).  Use the
+[search expressions](../overview.md#7-search-expressions).  Use the
 [search operator](search.md) if you want search syntax.
 
 When Zed queries are run interactively, it is highly convenient to be able to omit

--- a/versioned_docs/version-v1.1.0/language/operators/yield.md
+++ b/versioned_docs/version-v1.1.0/language/operators/yield.md
@@ -12,10 +12,10 @@ yield <expr> [, <expr>...]
 The `yield` operator produces output values by evaluating one or more
 expressions on each input value and sending each result to the output
 in left-to-right order.  Each `<expr>` may be any valid
-[Zed expression](../README.md#expressions).
+[Zed expression](../overview.md#6-expressions).
 
 The _yield_ keyword may be omitted when `<expr>` is a
-[record literal](../README.md#record-literal).
+[record literal](../overview.md#6112-record-expressions).
 
 ### Examples
 

--- a/versioned_docs/version-v1.1.0/language/overview.md
+++ b/versioned_docs/version-v1.1.0/language/overview.md
@@ -20,7 +20,7 @@ However, in Zed, the entities that transform data are called
 "operators" instead of "commands" and unlike Unix pipelines,
 the streams of data in a Zed query
 are typed data sequences that adhere to the
-[Zed data model](../formats/zed.md#the-zed-data-model-specification).
+[Zed data model](../formats/zed.md).
 Moreover, Zed sequences can be forked and joined:
 ```
 operator
@@ -156,7 +156,7 @@ The `search` and `where` operators "find" values in their input and drop
 the ones that do not match what is being looked for.
 
 The [yield operator](operators/yield.md#operator) emits one or more output values
-for each input value based on arbitrary [expressions](#expressions),
+for each input value based on arbitrary [expressions](#6-expressions),
 providing a convenient means to derive arbitrary output values as a function
 of each input value, much like the map concept in the MapReduce framework.
 
@@ -324,7 +324,7 @@ is abbreviated
 foo bar or x > 100
 ```
 Furthermore, if an operator-free expression is not valid syntax for
-a search expression but is a valid [Zed expression](#expressions),
+a search expression but is a valid [Zed expression](#6-expressions),
 then the abbreviation is treated as having an implied `yield` operator, e.g.,
 ```
 {s:lower(s)}
@@ -419,7 +419,7 @@ Named types may be created with the syntax
 ```
 type <id> = <type>
 ```
-where `<id>` is an identifier and `<type>` or a [Zed type](#first-class-types).
+where `<id>` is an identifier and `<type>` or a [Zed type](#51-first-class-types).
 This create a new type with the given name in the Zed type system, e.g.,
 ```mdtest-command
 echo 80 | zq -z 'type port=uint16 cast(this, <port>)' -
@@ -430,7 +430,7 @@ produces
 ```
 
 One or more type statements may appear at the beginning of a scope
-(i.e., the main scope at the start of a Zed program or a [lateral scope](#lateral-scope)
+(i.e., the main scope at the start of a Zed program or a [lateral scope](#81-lateral-scope)
 defined by an [over operator](operators/over.md#operator))
 and binds the identifier to the type in the scope in which it appears in addition
 to any contained scopes.
@@ -449,7 +449,7 @@ The syntax of individual literal values generally follows
 the [ZSON syntax](../formats/zson.md) with the exception that
 [type decorators](../formats/zson.md#22-type-decorators)
 are not included in the language.  Instead, a
-[type cast](#casts) may be used in any expression for explicit
+[type cast](#614-casts) may be used in any expression for explicit
 type conversion.
 
 In particular, the syntax of primitive types follows the
@@ -457,7 +457,7 @@ In particular, the syntax of primitive types follows the
 as well as the various [complex value definitions](../formats/zson.md#24-complex-values)
 like records, arrays, sets, and so forth.  However, complex values are not limited to
 constant values like ZSON and can be composed from literal expressions as
-[defined below](#expressions).
+[defined below](#611-literals).
 
 ### 5.1 First-class Types
 
@@ -874,7 +874,7 @@ in other languages and have the form
 <value> . <id>
 ```
 where `<id>` is an identifier representing the field name referenced.
-If a field name is not representable as an identifier, then [indexing](#indexing)
+If a field name is not representable as an identifier, then [indexing](#66-indexing)
 may be used with a quoted string to represent any valid field name.
 Such field names can be accessed using `this` and an array-style
 reference, e.g., `this["field with spaces"]`.
@@ -952,7 +952,7 @@ If the result is true, then the first `<expr>` expression is evaluated and becom
 the result.  Otherwise, the second `<expr>` expression is evaluated.
 
 Note that if the expression has side effects,
-as with [aggregation calls](#aggregation-calls), only the selected expression
+as with [aggregate function calls](#610-aggregate-function-calls), only the selected expression
 will be evaluated.
 
 For example,
@@ -1017,7 +1017,7 @@ produces just one output value
 
 ### 6.11 Literals
 
-Any of the [data types listed above](#data-types) may be used in expressions
+Any of the [data types listed above](#5-data-types) may be used in expressions
 as long as it is compatible with the semantics of the expression.
 
 String literals are enclosed in either single quotes or double quotes and
@@ -1193,7 +1193,7 @@ to determine the constant value assigned to the identifier `<id>`.
 This expression may not refer to `this` or any implied fields of `this`.
 
 Constants must appear at the beginning
-of a query or the beginning of a [parenthesized scope](#scopes).
+of a query or the beginning of a [parenthesized scope](#81-lateral-scope).
 
 ```mdtest-command
 echo '{diameter:1}{diameter:5}' | zq -z 'const PI = 3.14159 circumference:=2*PI*diameter' -
@@ -1223,7 +1223,7 @@ overridden by the input data; however, type values that refer to the named
 type may be redefined.
 
 Type definitions must appear at the beginning
-of a query or the beginning of a [parenthesized scope](#scopes).
+of a query or the beginning of a [parenthesized scope](#81-lateral-scope).
 
 ```mdtest-command
 echo '{s:1}{s:10.0.0.1}' | zq -z 'type foo = {s:string} cast(this, foo)' -
@@ -1573,7 +1573,7 @@ the "in" operator, e.g.,
 ##### 7.2.1.6 Predicate Search Term
 
 Any Boolean-valued [function](functions/README.md) like `is()`, `has()`,
-`grep()` etc. and any [comparison expression](#comparisons)
+`grep()` etc. and any [comparison expression](#62-comparisons)
 may be used as a search term and mixed into a search expression.
 
 For example,

--- a/versioned_docs/version-v1.1.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.1.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](../../testdata/edu) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.1.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](../../testdata/edu/README.md#creation).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.1.0/testdata/edu/README.md).
 
 ## 3. Searching
 
@@ -123,7 +123,7 @@ and we get just the one record that matches:
 Under the covers, a keyword search translates to Zed's [grep function](../language/functions/grep.md),
 which lets you search specific fields instead of the entire input value, e.g.,
 we can search for the string "bar" in the `City` field and list all the unique
-cities that match with a [group-by](#group-by):
+cities that match with a [group-by](#52-grouping):
 ```mdtest-command dir=testdata/edu
 zq -f text 'grep("bar", City) | by City | yield City | sort' schools.zson
 ```
@@ -145,7 +145,7 @@ other Unix tools that might not expect quotes.
 
 When the keyword you want to search for doesn't fit into the keyword syntax,
 i.e., it has spaces or special characters, you should use a
-[literal string search](#literal-search).
+[literal string search](#34-literal-search).
 
 ### 3.2 Globs
 
@@ -171,7 +171,7 @@ using the literal asterisk character embedded in the string.
 
 ### 3.3 Regular Expressions
 
-For pattern matching beyond [glob wildcards](#glob-wildcards),
+For pattern matching beyond [glob wildcards](#32-globs),
 regular expressions (regexps) are also
 available. To use them, simply place a `/` character before and after the
 regexp.
@@ -190,7 +190,7 @@ produces
 ...
 ```
 Further details for regular expressions are available in
-the [Zed language documention](#711-regular-expressions).
+the [Zed language documention](../language/overview.md#711-regular-expressions).
 
 ### 3.4 Literal Search
 
@@ -247,7 +247,7 @@ Quoted strings are particularly handy when you're looking for long, specific
 strings that may have several special characters in them. For example, let's
 say we're looking for information on the Union Hill Elementary district.
 Entered without quotes, we end up matching far more records than we intended
-since each space character between words is treated as a [Boolean `and`](#and), e.g.,
+since each space character between words is treated as a [Boolean `and`](#541-and), e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'Union Hill Elementary' schools.zson
 ```
@@ -277,7 +277,7 @@ produces
 ### 3.5 Predicate Search
 
 Search terms can also be include Boolean predicates adhering
-to Zed's [expression syntax](../language/README.md#6-expressions).
+to Zed's [expression syntax](../language/overview.md#6-expressions).
 
 In particular, a search result can be narrowed down
 to include only records that contain a
@@ -298,7 +298,7 @@ produces
 Because the right-hand-side value to which we were comparing was a string, it
 was necessary to wrap it in quotes. If this string were written as a keyword,
 it would have been interpreted as a field name as
-Zed [field references](../language/README.md#24-implied-field-references)
+Zed [field references](../language/overview.md#24-implied-field-references)
 look like keywords in the context of an expression.
 
 For example, to see the records in which the school and district name are the
@@ -380,7 +380,7 @@ produces
 {School:null(string),District:"Luther Burbank",City:"San Jose",County:"Santa Clara",Zip:"95128-1931",Latitude:37.323556,Longitude:-121.9267,Magnet:null(bool),OpenDate:null(time),ClosedDate:null(time),Phone:"(408) 295-2450",StatusType:"Active",Website:"www.lbsd.k12.ca.us"}
 ```
 
-[Regular expressions](#regular-expressions) can also be used with `grep`, e.g.,
+[Regular expressions](#33-regular-expressions) can also be used with `grep`, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'grep(/^Sunset (Ranch|Ridge) Elementary/, School)' schools.zson
 ```
@@ -398,7 +398,7 @@ This is performed with `in`.
 
 Since our sample data doesn't contain complex fields, we'll make one by
 using the [`union`](../language/aggregates/union.md) aggregate function to
-create a [`set`](../formats/zson.md#343-set-value)-typed
+create a [`set`](../formats/zson.md#243-set-value)-typed
 field called `Schools` that contains all unique school names per district. From
 these we'll find each set that contains a school named `Lincoln Elementary`, e.g.,
 ```mdtest-command dir=testdata/edu
@@ -465,7 +465,7 @@ produces
 ### 3.6 Boolean Logic
 
 Search terms can be combined with Boolean logic as detailed in
-the [Zed language documentation](#73-boolean-logic).
+the [Zed language documentation](../language/overview.md#73-boolean-logic).
 
 In particular, search terms separated by blank space implies
 Boolean `and` between the concatenated terms.
@@ -845,7 +845,7 @@ produces this compile-time error message and the query is not run:
 ```mdtest-output
 cannot rename outer.inner to toplevel
 ```
-This goal could instead be achieved by combining [`put`](#put) and [`drop`](#drop),
+This goal could instead be achieved by combining [`put`](#44-put) and [`drop`](#42-drop),
 e.g.,
 ```mdtest-command
 zq -Z 'put toplevel:=outer.inner | drop outer.inner' nested.zson
@@ -865,7 +865,7 @@ Each aggregation is performed by an
 [aggregate function](../language/aggregates/README.md)
 that operates on batches of records to carry out a running computation over
 the values they contain.  The `summarize` keyword is optional as the operato
-can be [inferred from context](../language/README.md#26-implied-operators).
+can be [inferred from context](../language/overview.md#26-implied-operators).
 
 As with SQL, multiple aggregate functions may be invoked at the same time.
 For example, to simultaneously calculate the minimum, maximum, and average of
@@ -930,7 +930,7 @@ produces
 ### 5.4 Aggregate Functions
 
 This section depicts examples of variou
-[aggregate functions](../language/README.md#aggregate-functions)
+[aggregate functions](../language/overview.md#610-aggregate-function-calls)
 operating over thes "schools data set".
 
 #### 5.4.1 [and](../language/aggregates/and.md)
@@ -1261,7 +1261,7 @@ San Francisco   San Francisco Unified                              454.368421052
 ...
 ```
 Instead of a simple field name, any of the comma-separated group-by elements
-can be any [Zed expression](../language/README.md#expressions), which may
+can be any [Zed expression](../language/overview.md#6-expressions), which may
 appear in the form of a field assignment `field:=expr`
 
 To see a count of how many school names of a particular character length
@@ -1284,7 +1284,7 @@ aggregation still proceeds but embeds any error conditions in the result,
 When a value is missing for a specified fiedl, it will appear as `error("missing")`.
 
 For instance, if we'd made an typographical error in our
-[prior example](#example-2) when attempting to reference the `dname` field,
+prior example when attempting to reference the `dname` field,
 the misspelled column would appear as embedded missing errors, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -f table 'avg(AvgScrRead),count() by cname,dnmae | sort -r count' testscores.zson
@@ -1340,7 +1340,7 @@ Here we'll find the counties with the most schools by using the
 [`count()`](../language/aggregates/count.md) aggregate function and piping its
 output to a `sort` in reverse order. Note that even though we didn't list a
 field name as an explicit argument, the `sort` operator did what we wanted
-because it found a field of the `uint64` [data type](../language/README.md#data-types),
+because it found a field of the `uint64` [data type](../language/overview.md#5-data-types),
 e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'count() by County | sort -r' schools.zson

--- a/versioned_docs/version-v1.1.0/tutorials/zed.md
+++ b/versioned_docs/version-v1.1.0/tutorials/zed.md
@@ -45,7 +45,7 @@ data since this will allow Zed to efficiently query data within a range of the
 pool key without having to touch the entire data set.
 
 For this primer we'll work with pull requests on this public repository via the
-[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).
+[GitHub API](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests).
 Let's create a pool to store this data and use the field `created_at` as the
 pool key, sorted in descending order:
 

--- a/versioned_docs/version-v1.1.0/tutorials/zq.md
+++ b/versioned_docs/version-v1.1.0/tutorials/zq.md
@@ -58,7 +58,7 @@ and you get
 ```
 With `zq`, the mysterious `jq` value `.` is instead called
 the almost-as-mysterious value
-[`this`](../language/README.md#23-the-special-value-this) and you say:
+[`this`](../language/overview.md#23-the-special-value-this) and you say:
 ```mdtest-command
 echo '1 2 3' | zq -z 'this+1' -
 ```
@@ -95,7 +95,7 @@ expression `2` is evaluated for each input value, and the value `2`
 is produced each time, so three copies of `2` are emitted.
 
 In `zq` however, `2` by itself is interpreted as a search and is
-[shorthand for](../language/README.md#26-implied-operators) `search 2` so the command
+[shorthand for](../language/overview.md#26-implied-operators) `search 2` so the command
 ```mdtest-command
 echo '1 2 3' | zq -z 2 -
 ```
@@ -268,7 +268,7 @@ As is often the case with semi-structured systems, you deal with
 nested values all the time: in JSON, data is nested with objects and arrays,
 while in Zed, data is nested with "records" and arrays (as well as other complex types).
 
-[Record expressions](../language/README.md#6112-record-expressions)
+[Record expressions](../language/overview.md#6112-record-expressions)
 are rather flexible with `zq` and look a bit like JavaScript
 or `jq` syntax, e.g.,
 ```mdtest-command
@@ -370,7 +370,7 @@ produces
 ## Union Types
 
 One of the tricks `zq` uses to represent JSON data in its structured type system
-is [union types](../language/README.md#6116-union-values).
+is [union types](../language/overview.md#6116-union-values).
 Most of the time, you don't need to worry about unions
 but they show up from time to time.  Even when
 they show up, Zed just tries to "do the right thing" so you usually
@@ -922,7 +922,7 @@ DATE                 NUMBER TITLE
 2019-11-12T16:49:07Z PR #6  a few clarifications to the zson spec
 ...
 ```
-Note that we used [string interpolation](../language/README.md#6111-string-interpolation)
+Note that we used [string interpolation](../language/overview.md#6111-string-interpolation)
 to convert the field `number` into a string and format it with surrounding text.
 
 Instead of old PRs, we can get the latest list of PRs using the
@@ -988,7 +988,7 @@ in the graph and each set of reviewers is another node.
 
 So as a first step, let's figure out how to create each edge, where an edge
 is a relation between the requesting user and the set of reviewers.  We can
-create this in Zed with a ["lateral subquery"](../language/README.md#8-lateral-subqueries).
+create this in Zed with a ["lateral subquery"](../language/overview.md#8-lateral-subqueries).
 Instead of computing a set-union over all the reviewers across all PRs,
 we instead want to compute the set-union over the reviewers in each PR.
 We can do this as follows:
@@ -1004,16 +1004,16 @@ which produces an output like this:
 {reviewers:|["henridf","mccanne","mattnibs"]|}
 ...
 ```
-Note that the syntax `=> ( ... )` defines a lateral scope where any Zed subquery can
+Note that the syntax `=> ( ... )` defines a [lateral scope](../language/overview.md#81-lateral-scope) where any Zed subquery can
 run in isolation over the input values created from the sequence of values
 traversed by the outer `over`.
 
 But we need a "graph edge" between the requesting user and the reviewers.
 To do this, we need to reference the `user.login` from the top-level scope within the
-[lateral scope](../language/README.md#81-lateral-scope).  This can be done by
+lateral scope].  This can be done by
 bringing that value into the scope using a `with` clause appended to the
 `over` expression and yielding a
-[record literal](../language/README.md#6112-record-expressions) with the desired value:
+[record literal](../language/overview.md#6112-record-expressions) with the desired value:
 ```mdtest-command dir=docs/tutorials
 zq -z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers}) | sort user,len(reviewers)' prs.zng
 ```

--- a/versioned_docs/version-v1.2.0/README.md
+++ b/versioned_docs/version-v1.2.0/README.md
@@ -47,9 +47,9 @@ across one or more [data pools](commands/zed.md#14-data-pools) with ACID commit 
 accessed via a [Git](https://git-scm.com/)-like API.
 * The [Zed language](language/README.md) is the system's dataflow language for performing
 queries, searches, analytics, transformations, or any of the above combined together.
-* A  [Zed query](language/README.md#1-introduction) is a Zed script that performs
+* A  [Zed query](language/overview.md#1-introduction) is a Zed script that performs
 search and/or analytics.
-* A [Zed shaper](language/README.md#9-shaping) is a Zed script that performs
+* A [Zed shaper](language/overview.md#9-shaping) is a Zed script that performs
 data transformation to _shape_
 the input data into the desired set of organizing Zed data types called "shapes",
 which are traditionally called _schemas_ in relational systems but are

--- a/versioned_docs/version-v1.2.0/commands/zed.md
+++ b/versioned_docs/version-v1.2.0/commands/zed.md
@@ -32,7 +32,7 @@ sidebar_label: zed
 A Zed lake is a cloud-native arrangement of data, optimized for search,
 analytics, ETL, data discovery, and data preparation
 at scale based on data represented in accordance
-with the [Zed data model](../formats).
+with the [Zed data model](../formats/zed.md).
 
 A lake is organized into a collection of data pools forming a single
 administrative domain.  The current implementation supports
@@ -52,7 +52,7 @@ A core theme of the Zed lake design is _ergonomics_.  Given the Git metaphor,
 our goal here is that the Zed lake tooling be as easy and familiar as Git is
 to a technical user.
 
-Since Zed lakes are built around the [Zed data model](../formats/zed.md),
+Since Zed lakes are built around the Zed data model,
 getting different kinds of data into and out of a lake is easy.
 There is no need to define schemas or tables and then fit
 semi-structured data into schemas before loading data into a lake.
@@ -245,7 +245,7 @@ As pool data is often comprised of Zed records (analogous to JSON objects),
 the pool key is typically a field of the stored records.
 When pool data is not structured as records/objects (e.g., scalar or arrays or other
 non-record types), then the pool key would typically be configured
-as the [special value `this`](../language/README.md#23-the-special-value-this).
+as the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 Data can be efficiently scanned via ranges of values conforming to the pool key.
 
@@ -444,7 +444,7 @@ The `-orderby` option indicates the pool key that is used to sort
 the data in lake, which may be in ascending or descending order.
 
 If a pool key is not specified, then it defaults to
-the [special value `this`](../language/README.md#23-the-special-value-this).
+the [special value `this`](../language/overview.md#23-the-special-value-this).
 
 A newly created pool is initialized with a branch called `main`.
 

--- a/versioned_docs/version-v1.2.0/commands/zq.md
+++ b/versioned_docs/version-v1.2.0/commands/zq.md
@@ -50,7 +50,7 @@ default format when output is directed to the terminal.  ZNG is the default
 when redirecting to a non-terminal output like a file or pipe.
 
 When run with input arguments, each input's format is automatically inferred
-([as described below](#21-auto-detection)) and each input is scanned
+([as described below](#22-auto-detection)) and each input is scanned
 in the order appearing on the command line forming the input stream.
 
 A query expressed in the [Zed language](../language/README.md)
@@ -88,7 +88,7 @@ emits
 ```mdtest-output
 2
 ```
-Note here that the query `1+1` [implies](../language/README.md#26-implied-operators)
+Note here that the query `1+1` [implies](../language/overview.md#26-implied-operators)
 `yield 1+1`.
 
 ## 2. Input Formats
@@ -351,7 +351,7 @@ If you are ever stumped about how the `zq` compiler is parsing your query,
 you can always run `zq -C` to compile and display your query in canonical form
 without running it.
 This can be especially handy when you are learning the language and
-[its shortcuts](../language/README.md#26-implied-operators).
+[its shortcuts](../language/overview.md#26-implied-operators).
 
 For example, this query
 ```mdtest-command
@@ -380,7 +380,7 @@ as soon as they happen and cause the `zq` process to exit.
 On the other hand,
 runtime errors resulting from the Zed query itself
 do not halt execution.  Instead, these error conditions produce
-[first-class Zed errors](../language/README.md#53-first-class-errors)
+[first-class Zed errors](../language/overview.md#53-first-class-errors)
 in the data output stream interleaved with any valid results.
 Such errors are easily queried with the
 [is_error function](../language/functions/is_error.md).
@@ -421,7 +421,7 @@ echo <values> | zq <query> -
 which is used throughout the [language documentation](../language/README.md)
 and [operator reference](../language/operators/README.md).
 
-The language documentation and [tutorials directory](../tutorials)
+The language documentation and [tutorials directory](../tutorials/README.md)
 have many examples, but here are a few more simple `zq` use cases.
 
 _Hello, world_
@@ -529,7 +529,7 @@ for sparse results, many frames are discarded without their uncompressed bytes
 having to be processed any further.
 
 While this pre-search technique results in very fast brute-force pattern matching,
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 can also be created when Zed data is managed by a Zed lake
 thereby avoiding scans of data altogether as the index pinpoints the locations
 of specific values in the lake.
@@ -545,7 +545,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed/blob/v1.2.0/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -582,7 +582,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](../../zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.2.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install
@@ -698,7 +698,7 @@ However, the benefit of Zed is that no flattening is required.  And unlike `sqli
 performance techniques cannot be applied to the Zed model and this is precisely what the
 open-source Zed project intends to do.  As a first step, with a
 [Zed lake](zed.md), you can build type-flexible
-[search indexes](zed.md#search-indexes)
+[search indexes](zed.md#16-search-indexes)
 to scale searches across very large stores of Zed data.
 
 Stay tuned!

--- a/versioned_docs/version-v1.2.0/formats/README.md
+++ b/versioned_docs/version-v1.2.0/formats/README.md
@@ -43,7 +43,7 @@ Instead, file formats like Avro, ORC, and Parquet arose to represent tabular dat
 with an explicit schema followed by a sequence of values that conform to the schema.
 While Avro and Parquet schemas can also represent semi-structured data, all of the
 values in a given Avro or Parquet file must conform to the same schema.
-The [Iceberg specification](https://iceberg.apache.org/#spec/)
+The [Iceberg specification](https://iceberg.apache.org/spec/)
 defines data types and metadata schemas for how large relational tables can be
 managed as a collection of Avro, ORC, and/or Parquet files.
 
@@ -275,7 +275,7 @@ embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
 the [Zealot JavaScript library](https://github.com/brimdata/zealot)
-and the [Zed Python library](../../python/zed).
+and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between
 a human-readable form, a row-based binary form, and a row-based columnar form can

--- a/versioned_docs/version-v1.2.0/install.md
+++ b/versioned_docs/version-v1.2.0/install.md
@@ -35,7 +35,7 @@ architectures in the Zed [Github Release page](https://github.com/brimdata/zed/r
 
 Each archive includes the build for `zq` and `zed`.
 
-Once installed, run a [quick test](#hello-world).
+Once installed, run a [quick test](#quick-tests).
 
 ## Building from source
 

--- a/versioned_docs/version-v1.2.0/language/README.md
+++ b/versioned_docs/version-v1.2.0/language/README.md
@@ -3,5 +3,5 @@
 The language documents:
 * provide an [overview](overview.md) of the Zed language,
 * layout some [conventions](conventions.md) for the documenation, and
-* enumerate the [operators](operators), [functions](functions),
-and [aggregate functions](aggregates) in reference format.
+* enumerate the [operators](operators/README.md), [functions](functions/README.md),
+and [aggregate functions](aggregates/README.md) in reference format.

--- a/versioned_docs/version-v1.2.0/language/aggregates/fuse.md
+++ b/versioned_docs/version-v1.2.0/language/aggregates/fuse.md
@@ -8,7 +8,7 @@ fuse(any) -> type
 ```
 ### Description
 
-The _fuse_ aggregate function applies [type fusion](../README.md#type-fusion)
+The _fuse_ aggregate function applies [type fusion](../overview.md#10-type-fusion)
 to its input and returns the fused type.
 
 This aggregation is useful with group-by for data exploration and discovery  

--- a/versioned_docs/version-v1.2.0/language/functions/grep.md
+++ b/versioned_docs/version-v1.2.0/language/functions/grep.md
@@ -12,8 +12,8 @@ grep(<pattern> [, e: any]) -> bool
 The _grep_ function searches all of the strings in its input value `e`
 (or `this` if `e` is not given)
  using the `<pattern>` argument, which must be a
-[regular expression](../README.md#regular-expressions),
-[glob pattern](../README.md#globs), or string literal.
+[regular expression](../overview.md#711-regular-expressions),
+[glob pattern](../overview.md#712-globs), or string literal.
 If the pattern matches for any string, then the result is `true`.  Otherwise, it is `false`.
 
 > Note that string matches are case insensitive while regular expression

--- a/versioned_docs/version-v1.2.0/language/functions/typename.md
+++ b/versioned_docs/version-v1.2.0/language/functions/typename.md
@@ -9,7 +9,7 @@ typename(s: string) -> type
 ```
 ### Description
 
-The _typename_ function returns the [type](../../formats/zson.md#357-type-type) of the
+The _typename_ function returns the [type](../../formats/zson.md#25-types) of the
 named type give by `name` if it exists.  Otherwise, `error("missing")` is returned.
 
 ### Examples

--- a/versioned_docs/version-v1.2.0/language/functions/typeof.md
+++ b/versioned_docs/version-v1.2.0/language/functions/typeof.md
@@ -9,7 +9,7 @@ typeof(val: any) -> type
 ```
 ### Description
 
-The _typeof_ function returns the [type](../../formats/zson.md#357-type-type) of
+The _typeof_ function returns the [type](../../formats/zson.md#25-types) of
 its argument `val`.  Types in Zed are first class so the returned type is
 also a Zed value.  The type of a type is type `type`.
 

--- a/versioned_docs/version-v1.2.0/language/operators/cut.md
+++ b/versioned_docs/version-v1.2.0/language/operators/cut.md
@@ -10,7 +10,7 @@ cut <field>[:=<expr>] [, <field>[:=<expr>] ...]
 ### Description
 
 The `cut` operator extracts values from each input record in the
-form of one or more [field assignments](../README.md#field-assignments),
+form of one or more [field assignments](../overview.md#25-field-assignments),
 creating one field for each expression.  Unlike the `put` operator,
 which adds or modifies the fields of a record, `cut` retains only the
 fields enumerated, much like a SQL projection.
@@ -34,7 +34,7 @@ resulting in `error("missing")` for expressions that reference fields of `this`.
 
 Note that when the field references are all top level,
 `cut` is a special case of a yield with a
-[record literal](../README.md#record-literal) having the form:
+[record literal](../overview.md#6112-record-expressions) having the form:
 ```
 yield {<field>:<expr> [, <field>:<expr>...]}
 ```

--- a/versioned_docs/version-v1.2.0/language/operators/put.md
+++ b/versioned_docs/version-v1.2.0/language/operators/put.md
@@ -9,7 +9,7 @@ put <field>:=<expr> [, <field>:=<expr> ...]
 ### Description
 
 The `put` operator modifies its input with
-one or more [field assignments](../README.md#field-assignments).
+one or more [field assignments](../overview.md#25-field-assignments).
 Each expression is evaluated based on the input record
 and the result is either assigned to a new field of the input record if it does not
 exist, or the existing field is modified in its original location with the result.
@@ -23,7 +23,7 @@ a computed value cannot be referenced in another expression.  If you need
 to re-use a computed result, this can be done by chaining multiple `put` operators.
 
 The "put" keyword is optional since it is an
-[implied operators](../README.md#implied-operators).
+[implied operators](../overview.md#26-implied-operators).
 
 Each `<field>` expression must be a field reference expressed as a dotted path or one more
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,
@@ -35,7 +35,7 @@ For any input value that is not a record, an error is emitted.
 
 Note that when the field references are all top level,
 `put` is a special case of a `yield` with a
-[record literal](../README.md#record-literal)
+[record literal](../overview.md#6112-record-expressions)
 using a spread operator of the form:
 ```
 yield {...this, <field>:<expr> [, <field>:<expr>...]}

--- a/versioned_docs/version-v1.2.0/language/operators/search.md
+++ b/versioned_docs/version-v1.2.0/language/operators/search.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "search" keyword may be omitted in which case `<sexpr>` follows
-the [search expression](../README.md#search-expressions) syntax.
+the [search expression](../overview.md#7-search-expressions) syntax.
 
 When Zed queries are run interactively, it is convenient to be able to omit
 the "search" keyword, but when search filters appear in Zed source files,

--- a/versioned_docs/version-v1.2.0/language/operators/where.md
+++ b/versioned_docs/version-v1.2.0/language/operators/where.md
@@ -13,7 +13,7 @@ to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
 The "where" keyword requires a regular Zed expression and does not support
-[search expressions](../README.md#search-expressions).  Use the
+[search expressions](../overview.md#7-search-expressions).  Use the
 [search operator](search.md) if you want search syntax.
 
 When Zed queries are run interactively, it is highly convenient to be able to omit

--- a/versioned_docs/version-v1.2.0/language/operators/yield.md
+++ b/versioned_docs/version-v1.2.0/language/operators/yield.md
@@ -12,10 +12,10 @@ yield <expr> [, <expr>...]
 The `yield` operator produces output values by evaluating one or more
 expressions on each input value and sending each result to the output
 in left-to-right order.  Each `<expr>` may be any valid
-[Zed expression](../README.md#expressions).
+[Zed expression](../overview.md#6-expressions).
 
 The _yield_ keyword may be omitted when `<expr>` is a
-[record literal](../README.md#record-literal).
+[record literal](../overview.md#6112-record-expressions).
 
 ### Examples
 

--- a/versioned_docs/version-v1.2.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.2.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](../../testdata/edu) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.2.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](../../testdata/edu/README.md#creation).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.2.0/testdata/edu/README.md).
 
 ## 3. Searching
 
@@ -123,7 +123,7 @@ and we get just the one record that matches:
 Under the covers, a keyword search translates to Zed's [grep function](../language/functions/grep.md),
 which lets you search specific fields instead of the entire input value, e.g.,
 we can search for the string "bar" in the `City` field and list all the unique
-cities that match with a [group-by](#group-by):
+cities that match with a [group-by](#52-grouping):
 ```mdtest-command dir=testdata/edu
 zq -f text 'grep("bar", City) | by City | yield City | sort' schools.zson
 ```
@@ -145,7 +145,7 @@ other Unix tools that might not expect quotes.
 
 When the keyword you want to search for doesn't fit into the keyword syntax,
 i.e., it has spaces or special characters, you should use a
-[literal string search](#literal-search).
+[literal string search](#34-literal-search).
 
 ### 3.2 Globs
 
@@ -171,7 +171,7 @@ using the literal asterisk character embedded in the string.
 
 ### 3.3 Regular Expressions
 
-For pattern matching beyond [glob wildcards](#glob-wildcards),
+For pattern matching beyond [glob wildcards](#32-globs),
 regular expressions (regexps) are also
 available. To use them, simply place a `/` character before and after the
 regexp.
@@ -190,7 +190,7 @@ produces
 ...
 ```
 Further details for regular expressions are available in
-the [Zed language documention](#711-regular-expressions).
+the [Zed language documention](../language/overview.md#711-regular-expressions).
 
 ### 3.4 Literal Search
 
@@ -247,7 +247,7 @@ Quoted strings are particularly handy when you're looking for long, specific
 strings that may have several special characters in them. For example, let's
 say we're looking for information on the Union Hill Elementary district.
 Entered without quotes, we end up matching far more records than we intended
-since each space character between words is treated as a [Boolean `and`](#and), e.g.,
+since each space character between words is treated as a [Boolean `and`](#541-and), e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'Union Hill Elementary' schools.zson
 ```
@@ -277,7 +277,7 @@ produces
 ### 3.5 Predicate Search
 
 Search terms can also be include Boolean predicates adhering
-to Zed's [expression syntax](../language/README.md#6-expressions).
+to Zed's [expression syntax](../language/overview.md#6-expressions).
 
 In particular, a search result can be narrowed down
 to include only records that contain a
@@ -298,7 +298,7 @@ produces
 Because the right-hand-side value to which we were comparing was a string, it
 was necessary to wrap it in quotes. If this string were written as a keyword,
 it would have been interpreted as a field name as
-Zed [field references](../language/README.md#24-implied-field-references)
+Zed [field references](../language/overview.md#24-implied-field-references)
 look like keywords in the context of an expression.
 
 For example, to see the records in which the school and district name are the
@@ -380,7 +380,7 @@ produces
 {School:null(string),District:"Luther Burbank",City:"San Jose",County:"Santa Clara",Zip:"95128-1931",Latitude:37.323556,Longitude:-121.9267,Magnet:null(bool),OpenDate:null(time),ClosedDate:null(time),Phone:"(408) 295-2450",StatusType:"Active",Website:"www.lbsd.k12.ca.us"}
 ```
 
-[Regular expressions](#regular-expressions) can also be used with `grep`, e.g.,
+[Regular expressions](#33-regular-expressions) can also be used with `grep`, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'grep(/^Sunset (Ranch|Ridge) Elementary/, School)' schools.zson
 ```
@@ -398,7 +398,7 @@ This is performed with `in`.
 
 Since our sample data doesn't contain complex fields, we'll make one by
 using the [`union`](../language/aggregates/union.md) aggregate function to
-create a [`set`](../formats/zson.md#343-set-value)-typed
+create a [`set`](../formats/zson.md#243-set-value)-typed
 field called `Schools` that contains all unique school names per district. From
 these we'll find each set that contains a school named `Lincoln Elementary`, e.g.,
 ```mdtest-command dir=testdata/edu
@@ -465,7 +465,7 @@ produces
 ### 3.6 Boolean Logic
 
 Search terms can be combined with Boolean logic as detailed in
-the [Zed language documentation](#73-boolean-logic).
+the [Zed language documentation](../language/overview.md#73-boolean-logic).
 
 In particular, search terms separated by blank space implies
 Boolean `and` between the concatenated terms.
@@ -845,7 +845,7 @@ produces this compile-time error message and the query is not run:
 ```mdtest-output
 cannot rename outer.inner to toplevel
 ```
-This goal could instead be achieved by combining [`put`](#put) and [`drop`](#drop),
+This goal could instead be achieved by combining [`put`](#44-put) and [`drop`](#42-drop),
 e.g.,
 ```mdtest-command
 zq -Z 'put toplevel:=outer.inner | drop outer.inner' nested.zson
@@ -865,7 +865,7 @@ Each aggregation is performed by an
 [aggregate function](../language/aggregates/README.md)
 that operates on batches of records to carry out a running computation over
 the values they contain.  The `summarize` keyword is optional as the operato
-can be [inferred from context](../language/README.md#26-implied-operators).
+can be [inferred from context](../language/overview.md#26-implied-operators).
 
 As with SQL, multiple aggregate functions may be invoked at the same time.
 For example, to simultaneously calculate the minimum, maximum, and average of
@@ -930,7 +930,7 @@ produces
 ### 5.4 Aggregate Functions
 
 This section depicts examples of variou
-[aggregate functions](../language/README.md#aggregate-functions)
+[aggregate functions](../language/overview.md#610-aggregate-function-calls)
 operating over thes "schools data set".
 
 #### 5.4.1 [and](../language/aggregates/and.md)
@@ -1261,7 +1261,7 @@ San Francisco   San Francisco Unified                              454.368421052
 ...
 ```
 Instead of a simple field name, any of the comma-separated group-by elements
-can be any [Zed expression](../language/README.md#expressions), which may
+can be any [Zed expression](../language/overview.md#6-expressions), which may
 appear in the form of a field assignment `field:=expr`
 
 To see a count of how many school names of a particular character length
@@ -1284,7 +1284,7 @@ aggregation still proceeds but embeds any error conditions in the result,
 When a value is missing for a specified fiedl, it will appear as `error("missing")`.
 
 For instance, if we'd made an typographical error in our
-[prior example](#example-2) when attempting to reference the `dname` field,
+prior example when attempting to reference the `dname` field,
 the misspelled column would appear as embedded missing errors, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -f table 'avg(AvgScrRead),count() by cname,dnmae | sort -r count' testscores.zson
@@ -1340,7 +1340,7 @@ Here we'll find the counties with the most schools by using the
 [`count()`](../language/aggregates/count.md) aggregate function and piping its
 output to a `sort` in reverse order. Note that even though we didn't list a
 field name as an explicit argument, the `sort` operator did what we wanted
-because it found a field of the `uint64` [data type](../language/README.md#data-types),
+because it found a field of the `uint64` [data type](../language/overview.md#5-data-types),
 e.g.,
 ```mdtest-command dir=testdata/edu
 zq -z 'count() by County | sort -r' schools.zson

--- a/versioned_docs/version-v1.2.0/tutorials/zed.md
+++ b/versioned_docs/version-v1.2.0/tutorials/zed.md
@@ -45,7 +45,7 @@ data since this will allow Zed to efficiently query data within a range of the
 pool key without having to touch the entire data set.
 
 For this primer we'll work with pull requests on this public repository via the
-[Github API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).
+[GitHub API](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests).
 Let's create a pool to store this data and use the field `created_at` as the
 pool key, sorted in descending order:
 

--- a/versioned_docs/version-v1.2.0/tutorials/zq.md
+++ b/versioned_docs/version-v1.2.0/tutorials/zq.md
@@ -58,7 +58,7 @@ and you get
 ```
 With `zq`, the mysterious `jq` value `.` is instead called
 the almost-as-mysterious value
-[`this`](../language/README.md#23-the-special-value-this) and you say:
+[`this`](../language/overview.md#23-the-special-value-this) and you say:
 ```mdtest-command
 echo '1 2 3' | zq -z 'this+1' -
 ```
@@ -95,7 +95,7 @@ expression `2` is evaluated for each input value, and the value `2`
 is produced each time, so three copies of `2` are emitted.
 
 In `zq` however, `2` by itself is interpreted as a search and is
-[shorthand for](../language/README.md#26-implied-operators) `search 2` so the command
+[shorthand for](../language/overview.md#26-implied-operators) `search 2` so the command
 ```mdtest-command
 echo '1 2 3' | zq -z 2 -
 ```
@@ -268,7 +268,7 @@ As is often the case with semi-structured systems, you deal with
 nested values all the time: in JSON, data is nested with objects and arrays,
 while in Zed, data is nested with "records" and arrays (as well as other complex types).
 
-[Record expressions](../language/README.md#6112-record-expressions)
+[Record expressions](../language/overview.md#6112-record-expressions)
 are rather flexible with `zq` and look a bit like JavaScript
 or `jq` syntax, e.g.,
 ```mdtest-command
@@ -370,7 +370,7 @@ produces
 ## Union Types
 
 One of the tricks `zq` uses to represent JSON data in its structured type system
-is [union types](../language/README.md#6116-union-values).
+is [union types](../language/overview.md#6116-union-values).
 Most of the time, you don't need to worry about unions
 but they show up from time to time.  Even when
 they show up, Zed just tries to "do the right thing" so you usually
@@ -922,7 +922,7 @@ DATE                 NUMBER TITLE
 2019-11-12T16:49:07Z PR #6  a few clarifications to the zson spec
 ...
 ```
-Note that we used [string interpolation](../language/README.md#6111-string-interpolation)
+Note that we used [string interpolation](../language/overview.md#6111-string-interpolation)
 to convert the field `number` into a string and format it with surrounding text.
 
 Instead of old PRs, we can get the latest list of PRs using the
@@ -988,7 +988,7 @@ in the graph and each set of reviewers is another node.
 
 So as a first step, let's figure out how to create each edge, where an edge
 is a relation between the requesting user and the set of reviewers.  We can
-create this in Zed with a ["lateral subquery"](../language/README.md#8-lateral-subqueries).
+create this in Zed with a ["lateral subquery"](../language/overview.md#8-lateral-subqueries).
 Instead of computing a set-union over all the reviewers across all PRs,
 we instead want to compute the set-union over the reviewers in each PR.
 We can do this as follows:
@@ -1004,16 +1004,16 @@ which produces an output like this:
 {reviewers:|["henridf","mccanne","mattnibs"]|}
 ...
 ```
-Note that the syntax `=> ( ... )` defines a lateral scope where any Zed subquery can
+Note that the syntax `=> ( ... )` defines a [lateral scope](../language/overview.md#81-lateral-scope) where any Zed subquery can
 run in isolation over the input values created from the sequence of values
 traversed by the outer `over`.
 
 But we need a "graph edge" between the requesting user and the reviewers.
 To do this, we need to reference the `user.login` from the top-level scope within the
-[lateral scope](../language/README.md#81-lateral-scope).  This can be done by
+lateral scope.  This can be done by
 bringing that value into the scope using a `with` clause appended to the
 `over` expression and yielding a
-[record literal](../language/README.md#6112-record-expressions) with the desired value:
+[record literal](../language/overview.md#6112-record-expressions) with the desired value:
 ```mdtest-command dir=docs/tutorials
 zq -z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers}) | sort user,len(reviewers)' prs.zng
 ```


### PR DESCRIPTION
These changes make it such that a link checker can run clean on the docs site. A successful test of this compares a one-off link checker run against a test site that has these changes deployed, next to the same link checker running against the current production site that still has plenty of broken links.

* Successful test run - https://github.com/philrz/scratchwiki/runs/7582560622?check_suite_focus=true
* Failing on production - https://github.com/philrz/scratchwiki/runs/7582483873?check_suite_focus=true

The initial motivation for taking this on was HTTP 404 errors on test data links described in #26, which was found to be related to known Docusaurus issue https://github.com/facebook/docusaurus/issues/6282. Therefore this change includes the removal of trailing slashes. In addition to the link checker running clean, you can run your own manual smoke test to see it's a safe change by following a link that still has a trailing slash such as https://philrz.github.io/docs/next/language/ and seeing that it lands safely at the correct destination page. If you then click to another page in the menu and then back to the Language page, you can see it's normally rendered without the trailing slash. But it's still happy to accept people who arrived by following a link that had the trailing slash, such as if we're linking to it from blog posts and such.

While the fix does allow these test data files to now be downloaded successfully, file assets apparently get saved with unique names, so while[ an example markdown reference in docs/tutorials/zed.md](https://github.com/brimdata/zed/blob/11a0017958cd076d96d7e6eadd20e50dad086c35/docs/tutorials/zed.md?plain=1#L71) might look like `[here](github1.zng)`, when the user finally clicks it in the site it downloads with a filename like `github1-2496d524ce44f4cb9f32cfeb70fa669e.zng`. I looked into this a bit and it seems like the HTML way to deal with this would be to add a `download="github1.zng"` attribute next to the `href` in the link of the rendered HTML. I'm surprised Docusaurus doesn't do this automatically, and oddly I couldn't seem to find open issues of people complaining about this. In any case, while we could post-process the HTML to add this, I'm inclined to skip the effort. I figure if a user is engaged enough to go through the tutorial, they'll be tolerant of what's going on, perhaps by hitting autocomplete in their shell when repeating the command lines from the tutorial.

In the process of pursuing the primary issue, the link checker picked up on a bunch of other breakages that the simpler markdown-level link checker in the Zed repo misses. Therefore this PR includes backports of fixes from https://github.com/brimdata/zed/pull/4004, https://github.com/brimdata/zed/pull/4028, https://github.com/brimdata/zed/pull/4040, and https://github.com/brimdata/zed/pull/4042 to all the older doc versions.

If this PR is approved and merged, I'll follow up with an addition to the Actions Workflows to run this link checker each time the site gets deployed to make sure we stay clean.

Fixes #26
