### PR TITLE
Run link checker after deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,3 +40,8 @@ jobs:
           curl -X POST -H "Content-Type: application/json" \
                --user "${{ secrets.ALGOLIA_CRAWLER_APP_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \
                "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex"
+      - name: Check for broken links
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: https://zed.brimdata.io
+          cmd_params: --buffer-size=8192 --header="Accept-Encoding:zstd,br,gzip,deflate" --exclude algolia.net --exclude www.googletagmanager.com


### PR DESCRIPTION
Recent fixes have made it such that a link checker now runs cleanly against the production docs site. Here's proof:

https://github.com/philrz/scratchwiki/runs/7583336600?check_suite_focus=true

To keep things clean, this PR runs that same link checker config each time we deploy the site.

Fixes #28