### PR TITLE
Restore trailing slash

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   stylesheets: ["https://use.typekit.net/nll6rzm.css"],
   organizationName: "brimdata",
   projectName: "zed",
-  trailingSlash: false,
+  trailingSlash: true,
 
   plugins: [
     // This plugin allows, e.g, docs/ to be a symlink to ../zed/docs/.


### PR DESCRIPTION
The move to `trailingSlash: false` in #30 seemed effective during testing, but once deployed to production, a tricky problem became evident. Under the new config, it’s true that when putting a URL like https://zed.brimdata.io/docs/language/ into your browser, you'd still end up at the right page. But on closer inspection, come to find out what’s actually happening is that there’s briefly a 404, then something else happens to push past it and land in the correct page. It happens so fast in a browser it’s easy to miss. But of course an automated link checker halts as soon as it sees the 404 and assumes a problem. Since the docs site itself was only linking to its own pages without trailing slashes, its own link checker never spotted this. But once the nightly link checkers started running for www.brimdata.io and the Brim/Brimcap wikis, the links-with-slashes from there to the docs pages started failing with 404.

In theory I'm up for removing the trailing slashes from the links on the other sites, but @nwt made the good point that we should pause and think more about it first. Indeed, I have a possible way to fix the asset links discussed in #26 even while maintaining the `trailingSlash: true` config overall, but I still need to work some kinks out of that.

In the meantime, this just restores the `trailingSlash: true` config, which means those asset links remain broken for the moment (I've reopened #26). You can see in an Actions run on a test docs site at https://github.com/philrz/scratchwiki/runs/7592497422?check_suite_focus=true that these are the only broken links with that config, so it seems the safest state to be in for the moment.