### PR TITLE
Postprocess HTML to fix asset links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ fetch:
 build: fetch
 	@yarn install --frozen-lockfile
 	@yarn build
+	@echo
+	@echo "Fixing asset links with trailing slashes in these files:"
+	@echo
+	@find build -name \*.html -exec egrep -q '(href="\/assets\/files\/)(\w+)(-[0-9a-f]+)(\.\w+)\/"' {} \; -print -exec perl -i -pe 's/(href="\/assets\/files\/)(\w+)(-[0-9a-f]+)(\.\w+)\/"/download="$$2$$4" $$1$$2$$3$$4"/' {} \;
+	@echo
+	@echo "Done!"
+
 .PHONY: version
 version: fetch
 	yarn run docusaurus docs:version $(REF)


### PR DESCRIPTION
## tl;dr

This is a draft change that I don't expect will be merged, but I'm sharing for educational purposes and to continue the debate of how to address #26.

## Details

I created the hacky `find`+`perl` search & replace in this PR to post-process the HTML to find & fix the asset links to remove their trailing slashes. This way we could maintain the overall Docusaurus `trailingSlash: true` config that it seems like we need after all (#32) but prevent these rare asset links from 404-ing. The hack basically works, e.g., here's the output during a `make build` showing that it found & fixed the appropriate files:

```
...
Fixing asset links with trailing slashes in these files:

build/docs/next/tutorials/zed/index.html
build/docs/v1.1.0/tutorials/zed/index.html
build/docs/tutorials/zed/index.html

Done!
...
```

If you go straight to the relevant page at my test staging site https://philrz.github.io/docs/tutorials/zed/ it gives the impression that it's working as intended, since you can now click either of the test data links and it downloads successfully. Unfortunately, the same is not true if you start at another page like https://philrz.github.io/docs/ and then browse in the left-hand nav to **Tutorials > Zed** and click the same links, as it 404s once again.

With some explanation from @jameskerr, I now have a sense of what's going on. Apparently the site built by Docusaurus uses "hydration" such that you receive the true static HTML in the first page you land at, but after that as you click on other pages you get JavaScript deltas that ultimately renders the pages client-side. Apparently this can help with performance. What it means here though is that hacking the static HTML was not adequate since the original version with the broken links is still rendered by the JavaScript.

As it turns out, there's ways to force it to use the HTML version, including:

1. If I navigate to **Tutorials > Zed** and then do a manual refresh of the page, now the static HTML gets downloaded and rendered and so the fixed asset links are used.
2. If I set my browser to "Don't allow sites to use Javascript", now my browser only ever downloads the static HTML pages and so I always get the fixed asset links.

Obviously these aren't viable "fixes", though.

I really can't perceive any noticeable performance degradation from serving the static HTML, which doesn't surprise me since the docs site isn't particularly heavyweight. If there were an easy way to tell Docusaurus to not do this hydration I'd be open to proposing that config tweak. However, I found issue https://github.com/facebook/docusaurus/issues/3030, and while some of the technical details are lost on me, the fact it's still Open leads me to conclude there's no easy way to do this today. And I've been resistant to solutions that would involve us maintaining our own hacked fork of Docusaurus.

In conclusion, this seems like it was a dead end, but I'm putting it out there in case it triggers additional thoughts for anyone. For now, the only ideas I have for addressing the core issue are:

1. Revisit using absolute links for the test data as originally proposed at https://github.com/brimdata/zed/pull/4036
2. Go back to `trailingSlash: false` and remove the trailing slashes from all the links on our wikis and other places that link to the docs site so they no longer have the trailing slashes that cause the link checker 404 as described in #32

I'd be fine with either of these with a slight preference for the first, but I'm still open to better suggestions. Last I knew, @nwt was thinking this topic over as well.
