### PR TITLE
Deploy to Netlify

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for broken links
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          url: https://stellar-lebkuchen-6a326d.netlify.app
+          url: https://testzed.brimdata.io
           cmd_params:
             --verbose
             --buffer-size=8192

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,5 +35,15 @@ jobs:
       - name: Check for broken links
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          url: https://spiffy-gnome-8f2834.netlify.app/
-          cmd_params: --verbose --buffer-size=8192 --header="Accept-Encoding:zstd,br,gzip,deflate" --exclude algolia.net --exclude www.googletagmanager.com
+          url: https://stellar-lebkuchen-6a326d.netlify.app
+          cmd_params:
+            --verbose
+            --buffer-size=8192
+            --header="Accept-Encoding:zstd,br,gzip,deflate"
+            --exclude algolia.net
+            --exclude www.googletagmanager.com
+      - name: Trigger Algolia Crawler
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+               --user "${{ secrets.ALGOLIA_CRAWLER_APP_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \
+               "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,42 +1,39 @@
-name: Deploy to GitHub Pages
+name: Deploy to Netlify
 
 on:
   push:
     branches:
-      - main
-  repository_dispatch:
-    types: [zed-docs-update]
+      - netlify-deploy
   workflow_dispatch:
 
 jobs:
   deploy:
-    name: Deploy to GitHub Pages
+    name: Deploy to Netlify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - name: Build site
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: yarn
       - name: Build
         run: make build
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHubPages
-        uses: peaceiris/actions-gh-pages@v3
+      # Popular action to deploy to Netlify:
+      # Docs: https://github.com/marketplace/actions/netlify-actions
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com 
-      - name: Trigger Algolia Crawler
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-               --user "${{ secrets.ALGOLIA_CRAWLER_APP_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \
-               "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex"
+          # Build output to publish to Netlify
+          publish-dir: ./build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          production-branch: main
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: Check for broken links
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: https://spiffy-gnome-8f2834.netlify.app/
+          cmd_params: --verbose --buffer-size=8192 --header="Accept-Encoding:zstd,br,gzip,deflate" --exclude algolia.net --exclude www.googletagmanager.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,9 @@ name: Deploy to Netlify
 on:
   push:
     branches:
-      - netlify-deploy
+      - main
+  repository_dispatch:
+    types: [zed-docs-update]
   workflow_dispatch:
 
 jobs:
@@ -35,7 +37,7 @@ jobs:
       - name: Check for broken links
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          url: https://testzed.brimdata.io
+          url: https://zed.brimdata.io
           cmd_params:
             --verbose
             --buffer-size=8192

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Zed",
   tagline: "Data has never been easier.",
-  url: "https://testzed.brimdata.io",
+  url: "https://zed.brimdata.io",
   baseUrl: "/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Zed",
   tagline: "Data has never been easier.",
-  url: "https://stellar-lebkuchen-6a326d.netlify.app",
+  url: "https://testzed.brimdata.io",
   baseUrl: "/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Zed",
   tagline: "Data has never been easier.",
-  url: "https://zed.brimdata.io",
+  url: "https://stellar-lebkuchen-6a326d.netlify.app",
   baseUrl: "/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
@@ -16,7 +16,7 @@ const config = {
   stylesheets: ["https://use.typekit.net/nll6rzm.css"],
   organizationName: "brimdata",
   projectName: "zed",
-  trailingSlash: true,
+  trailingSlash: false,
 
   plugins: [
     // This plugin allows, e.g, docs/ to be a symlink to ../zed/docs/.


### PR DESCRIPTION
## Summary

Researching a fix for #26 taught us that GitHub Pages is probably not a great destination for the Docusaurus-based Zed docs site. The tl;dr is that the default Docusaurus `trailingSlash: true` config caused HTTP 404 errors on the asset links for sample ZNG data referenced from the [Zed tutorial](https://zed.brimdata.io/docs/tutorials/zed/), and an attempt to fix that by using an alternate `trailingSlash: false` config in Docusaurus caused a different failure as described in #32.

The table at https://github.com/slorber/trailing-slash-guide gives a nice summary to not only confirm what we saw with GitHub Pages but also points at a Netlify config that should work fine instead. The changes in this PR are a move to that Netlify config.

![image](https://user-images.githubusercontent.com/5934157/186553907-5e6e5221-4616-4b96-ae28-53cac01720af.png)

I've created a new Netlify account attached to docs@brimdata.io that's currently hosting a test deployment of the docs site at https://stellar-lebkuchen-6a326d.netlify.app. If this PR is approved, I'll proceed with the **Final Steps** list at the bottom of this PR text so that [zed.brimdata.io](https://zed.brimdata.io/) will ultimately point at the Netlify site going forward.

Fixes #26
Fixes #28

## Limits/Cost

We're currently using the free Netlify "Starter" level, which gives us a bandwidth allotment of 100 GB/mo. The next level up is "Pro" at $19/mo which provides bandwidth of 1 TB/mo. As I'm not sure just how much traffic the site gets, I'll plan to keep an eye on the bandwidth utilization and if the daily rate of increase puts us anywhere near danger of hitting the 100 GB/mo ceiling, we can start paying.

## DNS Config Deltas

I've created a temporary CNAME in our Google Cloud DNS settings to point [testzed.brimdata.io](https://testzed.brimdata.io/) at [stellar-lebkuchen-6a326d.netlify.app](https://stellar-lebkuchen-6a326d.netlify.app/) for the purposes of test & review of this PR. Once this PR is approved, the CNAME for zed.brimdata.io will be modified to point to stellar-lebkuchen-6a326d.netlify.app.

## Netlify Config Deltas

I confirmed that simply moving the docs site in its current state to Netlify with out-of-the-box default Netlify config does make it such that the asset links no longer HTTP 404. However, as also indicated by the table above and at https://docusaurus.io/docs/deployment#deploying-to-netlify, hitting the URLs with `curl` showed some "unnecessary redirects" happening behind the scenes. E.g., this is an HTTP 200:

```
$ curl -I https://stellar-lebkuchen-6a326d.netlify.app/docs/commands/zed/
HTTP/2 200 
```

...but if someone were to hit this _without_ the trailing slash, there's an HTTP 301 hop:

```
$ curl -I https://stellar-lebkuchen-6a326d.netlify.app/docs/commands/zed
HTTP/2 301 
```

Based on the advice from that Docusaurus link above, that led me to modify the Netlify config at **Site Settings > Build & Deploy > Asset Optimization** from this default:

![image](https://user-images.githubusercontent.com/5934157/186556548-cc28cad8-48a4-41ad-925b-a19c95b33dee.png)

To this:

![image](https://user-images.githubusercontent.com/5934157/186556641-16b67361-5796-436b-86d5-6da0f5a0738a.png)

Now we get a straight HTTP 200 on both variations of the link.

```
$ curl -I https://stellar-lebkuchen-6a326d.netlify.app/docs/commands/zed/
HTTP/2 200 

$ curl -I https://stellar-lebkuchen-6a326d.netlify.app/docs/commands/zed
HTTP/2 200 
```

I also added config under **Site Settings > Domain Management > Custom Domains** for `testzed.brimdata.io`, which was a prerequisite for the auto-generation of an SSL/TLS cert to have the site served securely when accessed via https://testzed.brimdata.io. Once this PR merges, I'll modify that **Custom Domain** config to point to zed.brimdata.io instead.

![image](https://user-images.githubusercontent.com/5934157/186751626-42c47525-5071-421a-92bf-d37f7727458c.png)

![image](https://user-images.githubusercontent.com/5934157/186751741-e475bf2b-4cee-4dc2-9d3e-fbd9f84432d1.png)

## Docusaurus Config Deltas

While Netlify changes alone got us to a clean link checker run without excessive redirects, with the default `trailingSlash: true` Docusaurus config, clicking the formerly-broken asset links discussed in #26 always resulted in a downloaded filename `download`. Moving to the `trailingSlash: false` config as is done in this PR improves this to where downloaded files from those asset links get filenames `github1-2496d524ce44f4cb9f32cfeb70fa669e.zng` and `github2-d64f82ea518d971a86ad9e81da3a9b6e.zng`, i.e., based on the original filenames in GitHub along with stuff to make it unique. This seems good enough to me.

## Broken Link Checking

Like we do with the www.brimdata.io web site, I went ahead and added a link checker to the deployment Action to quickly catch breakages. You can see in a [recent Action run](https://github.com/brimdata/zed-docs-site/actions/runs/2929059947) that it's running clean against the https://testzed.brimdata.io site.

I similarly wanted to avoid a repeat of what we saw on GitHub Pages in #32 that led to backing out the previous attempt at using `0trailingSlash: false`, so I made a test deployment of the www.brimdata.io web site at https://capable-khapse-fa9d06.netlify.app that has all the doc links in the blog articles pointing at https://testzed.brimdata.io, with the trailing slashes on the links in the blog posts left intact. You can see in [this Actions run](https://github.com/philrz/scratchwiki/runs/8023716331?check_suite_focus=true) that a link checker run against this test site also runs clean.

## Final Steps

Once this PR is approved, final changes before merge:

- [x] Change Docusaurus `url` config parameter back to `https://zed.brimdata.io`
- [x] In `deploy.yaml`, change the triggered branch back to `main` and restore the `repository_dispatch` config
- [x] Point the link checker config at https://zed.brimdata.io

Once the PR Is merged, final changes to migrate the production site:

- [ ] Change the zed.brimdata.io CNAME in our DNS config to point to stellar-lebkuchen-6a326d.netlify.app instead of GitHub Pages
- [ ] Change the **Custom domain** setting in Netlify from testzed.brimdata.io to zed.brimdata.io and ensure the auto-generated SSL/TLS cert works

Post-migration cleanup steps:

- [ ] In GitHub **Settings** for this repo, click **Unpublish site**
- [ ] Share Netlify secrets with the team (put in AWS Secrets Manager?)
- [ ] Keep an eye on bandwidth utilization over time to see if we stay well below the 100 GB/mo limit