### PR TITLE
Add _redirect config file as last build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REF = main
-LATEST := $(shell python3 -c 'import json; versions = json.load(open("versions.json")); versions.sort(); print(versions[-1])')
+LATEST = $(shell jq -r '.[0]' versions.json)
 
 .PHONY: fetch
 fetch:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REF = main
+LATEST := $(shell python3 -c 'import json; versions = json.load(open("versions.json")); versions.sort(); print(versions[-1])')
 
 .PHONY: fetch
 fetch:
@@ -12,6 +13,8 @@ fetch:
 build: fetch
 	@yarn install --frozen-lockfile
 	@yarn build
+	@echo "/docs/$(LATEST)/*	/docs/:splat" > build/_redirects
+
 .PHONY: version
 version: fetch
 	yarn run docusaurus docs:version $(REF)


### PR DESCRIPTION
## tl;dr

We can't currently link explicitly link to the "latest" Zed docs on zed.brimdata.io by using URLs that contain a GItHub tag. This PR adds a Netlify "redirects" config that fixes that.

## Background

Before we can address https://github.com/brimdata/brim/issues/2360, we need to work around a Docusaurus limitation. The table below from the [Docusaurus docs](https://docusaurus.io/docs/versioning) sets the scene.

![image](https://user-images.githubusercontent.com/5934157/186972863-71f0c75a-1ee7-4651-a5b5-1cee2825d361.png)

Let's translate that to an example in our world

For starters, the links in the original GitHub repo can always be referenced by explicit tag. These both work fine:

https://github.com/brimdata/zed/blob/v1.1.0/docs/tutorials/zed.md
https://github.com/brimdata/zed/blob/v1.2.0/docs/tutorials/zed.md

But due to what's described in that table, this link exists:

https://zed.brimdata.io/docs/v1.1.0/tutorials/zed

...but this one is a 404:

https://zed.brimdata.io/docs/v1.2.0/tutorials/zed

The page that corresponds to the `v1.2.0` tag would be found at https://zed.brimdata.io/docs/tutorials/zed. But we'd not want to ship a version of the app with that non-tagged URL baked into it, since the "latest" is going to keep changing as we release new Zed versions.

## The Fix

I tried to find a solution at the Docusaurus layer but was unsuccessful. For instance, there's [this unanswered StackOverflow question](https://stackoverflow.com/questions/72391261/can-the-same-version-support-multiple-routing-path). I also asked on their Discord server and nobody responded.

Thankfully, now that we're on Netlify, it looks like it can be addressed pretty well at that layer via their [redirects](https://docs.netlify.com/routing/redirects/) config. In this PR I've taken the approach of dynamically adding the `_redirects` config file to the completed `build` directory based on whatever the highest version number is in the `versions.json`. That way as long as the new version number is added to `versions.json` like was done in the most recent time we froze a tagged version (#21), the redirect for the new version will happen automatically.

## Testing

I have a test version of the site deployed in my personal Netlify where you can see for yourself that it's effective. For the link variations without/with trailing slash as well as anchor link, these all land in the correct place when clicked.

https://spiffy-gnome-8f2834.netlify.app/docs/v1.2.0/tutorials/zed
https://spiffy-gnome-8f2834.netlify.app/docs/v1.2.0/tutorials/zed/
https://spiffy-gnome-8f2834.netlify.app/docs/v1.2.0/tutorials/zed#time-travel

As for asset links to downloadable files, these never had version tags in the first place, hence are not affected by this change, e.g.:

https://spiffy-gnome-8f2834.netlify.app/assets/files/github1-2496d524ce44f4cb9f32cfeb70fa669e.zng
