### PR TITLE
Make Algolia crawl step fail when appropriate

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     name: Deploy to Netlify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Build site
@@ -46,6 +46,6 @@ jobs:
             --exclude www.googletagmanager.com
       - name: Trigger Algolia Crawler
         run: |
-          curl -X POST -H "Content-Type: application/json" \
+          curl -X POST -H "Content-Type: application/json" --fail-with-body \
                --user "${{ secrets.ALGOLIA_CRAWLER_APP_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \
                "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex"


### PR DESCRIPTION
It turns out the API-triggered Algolia crawl at the end of the docs site deployment has been failing for months. We've been missing it because, while the `curl` shows the error returned from the server as part of the HTTP 400 response, the `curl` itself still has an exit code of `0`, so that step of the workflow has been showing success.

![image](https://user-images.githubusercontent.com/5934157/200387213-c0fbf94a-f768-4ba1-8dba-99752c125a3f.png)

A web search revealed that the `--fail-with-body` option will make it start doing the right thing.

```
$ curl --fail-with-body -X POST -H "Content-Type: application/json" --user "xxx:xxx" "https://crawler.algolia.com/api/1/crawlers/xxx/reindex"
curl: (22) The requested URL returned error: 400
{"error":{"code":"Bad Request","message":"The credentials are not valid. See the 'errors' field for details","errors":[{"label":"userId","type":"internet.uuidv4","message":"userId must be a valid token"}]}}

$ echo $?
22
```

It turns out the Ubuntu 20.04 pointed at by `ubuntu-latest` has a `curl` old enough that it lacks this feature, so I've pinned to `ubuntu-22.04` here.

I also confirmed what the correct credentials are to make it work. Once this PR merges and we get to enjoy seeing it fail as it should, I'll put the correct credentials in AWS Secrets Manager, then replace the GitHub secrets with them, re-run the Workflow, and we'll be up & running again.