### PR TITLE
Exclude edit links from link checker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,6 +44,7 @@ jobs:
             --header="Accept-Encoding:zstd,br,gzip,deflate"
             --exclude algolia.net
             --exclude www.googletagmanager.com
+            --exclude github.com\/brimdata\/.*\/edit\/
       - name: Trigger Algolia Crawler
         run: |
           curl -X POST -H "Content-Type: application/json" --fail-with-body \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,8 +43,8 @@ jobs:
             --buffer-size=8192
             --header="Accept-Encoding:zstd,br,gzip,deflate"
             --exclude algolia.net
-            --exclude www.googletagmanager.com
             --exclude github.com\/brimdata\/.*\/edit\/
+            --exclude www.googletagmanager.com
       - name: Trigger Algolia Crawler
         run: |
           curl -X POST -H "Content-Type: application/json" --fail-with-body \


### PR DESCRIPTION
A couple days ago, the link checker that runs after deployment started failing with a burst of HTTP 429 errors. Example:

```
https://zed.brimdata.io/docs/language/operators/over
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fover.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/over.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/over
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fover.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/over.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/has
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fhas.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/has.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/log
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Flog.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/log.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/fields
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ffields.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/fields.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/merge
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fmerge.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/merge.md
https://zed.brimdata.io/docs/language/operators/merge
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fmerge.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/merge.md
https://zed.brimdata.io/docs/language/operators/from
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffrom.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/from.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/from
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffrom.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/from.md
https://zed.brimdata.io/docs/v1.1.0/language/aggregates/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Faggregates%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/aggregates/fuse.md
https://zed.brimdata.io/docs/language/aggregates/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Faggregates%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/aggregates/fuse.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/replace
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Freplace.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/replace.md
https://zed.brimdata.io/docs/next/language/functions/log
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Flog.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/log.md
https://zed.brimdata.io/docs/next/language/aggregates/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Faggregates%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/aggregates/fuse.md
https://zed.brimdata.io/docs/next/language/functions/fields
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ffields.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/fields.md
https://zed.brimdata.io/docs/next/language/operators/from
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffrom.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/from.md
https://zed.brimdata.io/docs/next/language/operators/merge
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fmerge.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/merge.md
https://zed.brimdata.io/docs/next/language/functions/has
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fhas.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/has.md
https://zed.brimdata.io/docs/next/language/operators/get
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fget.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/get.md
https://zed.brimdata.io/docs/next/language/operators/file
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffile.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/file.md
https://zed.brimdata.io/docs/next/language/operators/over
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fover.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/over.md
https://zed.brimdata.io/docs/next/language/functions/levenshtein
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Flevenshtein.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/levenshtein.md
https://zed.brimdata.io/docs/next/language/functions/regexp
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fregexp.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/regexp.md
https://zed.brimdata.io/docs/next/language/functions/replace
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Freplace.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/replace.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/compare
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fcompare.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/compare.md
https://zed.brimdata.io/docs/next/language/functions/compare
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fcompare.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/compare.md
https://zed.brimdata.io/docs/language/operators/where
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fwhere.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/where.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/where
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fwhere.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/where.md
https://zed.brimdata.io/docs/next/language/operators/where
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fwhere.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/where.md
https://zed.brimdata.io/docs/next/language/functions/trim
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ftrim.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/trim.md
https://zed.brimdata.io/docs/v1.1.0/language/functions/trim
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ftrim.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/trim.md
https://zed.brimdata.io/docs/next/language/functions/coalesce
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fcoalesce.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/coalesce.md
https://zed.brimdata.io/docs/commands/zed
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Fcommands%2Fzed.md)	https://github.com/brimdata/zed/edit/main/docs/commands/zed.md
https://zed.brimdata.io/docs/v1.1.0/lake/format
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flake%2Fformat.md)	https://github.com/brimdata/zed/edit/main/docs/lake/format.md
https://zed.brimdata.io/docs/lake/format
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flake%2Fformat.md)	https://github.com/brimdata/zed/edit/main/docs/lake/format.md
https://zed.brimdata.io/docs/v1.1.0/commands/zed
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Fcommands%2Fzed.md)	https://github.com/brimdata/zed/edit/main/docs/commands/zed.md
https://zed.brimdata.io/docs/next/lake/format
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flake%2Fformat.md)	https://github.com/brimdata/zed/edit/main/docs/lake/format.md
https://zed.brimdata.io/docs/next/commands/zed
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Fcommands%2Fzed.md)	https://github.com/brimdata/zed/edit/main/docs/commands/zed.md
https://zed.brimdata.io/docs/language/functions/replace
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Freplace.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/replace.md
https://zed.brimdata.io/docs/language/functions/has
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fhas.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/has.md
https://zed.brimdata.io/docs/language/functions/compare
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Fcompare.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/compare.md
https://zed.brimdata.io/docs/language/functions/trim
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ftrim.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/trim.md
https://zed.brimdata.io/docs/language/functions/log
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Flog.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/log.md
https://zed.brimdata.io/docs/language/functions/fields
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Ffunctions%2Ffields.md)	https://github.com/brimdata/zed/edit/main/docs/language/functions/fields.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/drop
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fdrop.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/drop.md
https://zed.brimdata.io/docs/language/operators/drop
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fdrop.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/drop.md
https://zed.brimdata.io/docs/next/language/operators/drop
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Fdrop.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/drop.md
https://zed.brimdata.io/docs/v1.1.0/language/operators/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/fuse.md
https://zed.brimdata.io/docs/next/language/operators/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/fuse.md
https://zed.brimdata.io/docs/language/operators/fuse
	429 (following redirect https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fbrimdata%2Fzed%2Fedit%2Fmain%2Fdocs%2Flanguage%2Foperators%2Ffuse.md)	https://github.com/brimdata/zed/edit/main/docs/language/operators/fuse.md
```

In an attempt to understand what's going on, I checked out a copy of the zed & zed-docs-site repos as they were the last time there was a successful link checker run that didn't show these HTTP 429 errors, then built/deployed the site to my personal test staging site on Netlify. Running a link checker against it, the HTTP 429 errors still came back. Therefore my best guess is that maybe GItHub recently became more strict with their rate limiter, perhaps specific to these edit links that trigger a login screen when coming from an anonymous client. Not sure.

In the interest of just getting past this, I confirmed in the same staging exercise that the change here of excluding these troublesome "edit" links shuts it up so it runs clean again. Really, the "Edit" buttons at the bottom of the doc site pages was not something I expected to see a lot of use anyway, so I'm not too bothered by losing the coverage.