### PR TITLE
Add a User-Agent header to muffet link check options

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,6 +41,7 @@ jobs:
           cmd_params:
             --verbose
             --buffer-size=8192
+            --header="User-Agent:Mozilla/5.0"
             --header="Accept-Encoding:zstd,br,gzip,deflate"
             --exclude algolia.net
             --exclude github.com\/brimdata\/.*\/edit\/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,8 +41,8 @@ jobs:
           cmd_params:
             --verbose
             --buffer-size=8192
-            --header="User-Agent:Mozilla/5.0"
             --header="Accept-Encoding:zstd,br,gzip,deflate"
+            --header="User-Agent:Mozilla/5.0"
             --exclude algolia.net
             --exclude github.com\/brimdata\/.*\/edit\/
             --exclude www.googletagmanager.com


### PR DESCRIPTION
The recent link checker failure at https://github.com/brimdata/zed-docs-site/actions/runs/3721440422/jobs/6311596205 shows an HTTP 403 at the destination AWS page. To resolve this I'm using the same trick I mentioned at https://github.com/brimdata/zui-docs-site/pull/1#discussion_r972200119 where adding a fake User Agent header shuts it up.  I've confirmed in a manual `muffet` run that this now runs clean.