### PR TITLE
Add zui.brimdata.io as an external site that can be clicked from search results

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,6 +128,7 @@ const config = {
         appId: "WZNIEWJ5O6",
         apiKey: "5b2387711eca356fb0d654336ae3f740",
         indexName: "zed-brimdata",
+        externalUrlRegex: "zui\\.brimdata\\.io",
       }
     }),
 };


### PR DESCRIPTION
Per https://github.com/brimdata/zui-docs-site/issues/5, the Algolia DocSearch support folks responded to our request to  enable `zui.brimdata.io` as a second site in our "application". I've since been able to add references to the site as a second entry under `startUrls`, `sitemaps`, `discoveryPatterns`, and `pathsToMatch` in our crawler config and the index has since rebuilt such that it now has additional entries for `zui.brimdata.io`. However, as also anticipated at https://github.com/brimdata/zui-docs-site/issues/5, as a next step we need to make the config change in this PR so that search results for that site will have a clickable URL that start with `zui.brimdata.io` instead of `zed.brimdata.io`. I've tested this out ok in the staging site at https://spiffy-gnome-8f2834.netlify.app/docs/next (e.g., type "suricata" into the **Search** tool and you'll get hits you can click successfully).

(Sadly, this does not get everything working to my satisfaction. At the moment the Zui search hits only come up if the user has "Next" selected from the **Version** drop down. I'm pretty sure I know what's going on and that this is down to "[contextual search](https://docusaurus.io/docs/search#contextual-search)". However, my digging through their docs has not yet given me solid ideas of what can be done to address it. I'm hoping to just get things partially working with the changes in this PR and then post a question on their user forum and see if anyone can help. I did find [this post](https://discourse.algolia.com/t/using-contextual-search-from-docusaurus-site-with-tags-facetfilter/13985) that looks roughly like what I was trying to achieve and sadly nobody responded to that person, but that was from 2021, so it's probably worth another go. If all of this is a dead end then maybe we need to bite the bullet and redesign everything into a single docs site as I've discussed in the past with @nwt, but it feels like a pretty significant undertaking so I'm inclined to spend a little time trying to extend the life of what we have if it's not too miserable.)