### PR TITLE
Fix broken links to Zeek integration doc

### DIFF
--- a/versioned_docs/version-v1.3.0/commands/zq.md
+++ b/versioned_docs/version-v1.3.0/commands/zq.md
@@ -582,7 +582,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.3.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.4.0/commands/zq.md
+++ b/versioned_docs/version-v1.4.0/commands/zq.md
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.4.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.5.0/commands/zq.md
+++ b/versioned_docs/version-v1.5.0/commands/zq.md
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.5.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.6.0/commands/zq.md
+++ b/versioned_docs/version-v1.6.0/commands/zq.md
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.6.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.7.0/commands/zq.md
+++ b/versioned_docs/version-v1.7.0/commands/zq.md
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.7.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.8.0/commands/zq.md
+++ b/versioned_docs/version-v1.8.0/commands/zq.md
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.8.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install


### PR DESCRIPTION
https://github.com/brimdata/zed/pull/4694 made these links in the old docs revisions stop working. I've confirmed with a [manual link checker run against a staging deploy](https://github.com/philrz/broken-link-checker/actions/runs/5449649644) that this should fix the link breakages on https://zed.brimdata.io.