### PR TITLE
Exclude Twitter from link checker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,7 @@ jobs:
             --header="User-Agent:Mozilla/5.0"
             --exclude algolia.net
             --exclude github.com\/brimdata\/.*\/edit\/
+            --exclude twitter.com
             --exclude www.googletagmanager.com
       - name: Trigger Algolia Crawler
         run: |


### PR DESCRIPTION
https://github.com/brimdata/website/pull/179 has the detailed explanation for why.