### PR TITLE
Fix NSJON links in older versioned docs

### DIFF
--- a/versioned_docs/version-v1.11.0/formats/README.md
+++ b/versioned_docs/version-v1.11.0/formats/README.md
@@ -54,7 +54,7 @@ Each JSON value is self-describing in terms of its
 structure and types, though the JSON type system is limited.
 
 When a sequence of JSON objects is organized into a stream
-(perhaps [separated by newlines](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON))
+(perhaps [separated by newlines](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON))
 each value can take on any form.
 When all the values have the same form, the JSON sequence
 begins to look like a relational table, but the lack of a comprehensive type system,

--- a/versioned_docs/version-v1.11.0/formats/zjson.md
+++ b/versioned_docs/version-v1.11.0/formats/zjson.md
@@ -268,7 +268,7 @@ and an array of union of string, and float64 --- might have a value that looks l
 ## 3. Object Framing
 
 A ZJSON file is composed of ZJSON objects formatted as
-[newline delimited JSON (NDJSON)](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON).
+[newline delimited JSON (NDJSON)](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON).
 e.g., the [zq](../commands/zq.md) CLI command
 writes its ZJSON output as lines of NDJSON.
 

--- a/versioned_docs/version-v1.11.0/integrations/zeek/reading-zeek-log-formats.md
+++ b/versioned_docs/version-v1.11.0/integrations/zeek/reading-zeek-log-formats.md
@@ -79,7 +79,7 @@ equivalent [rich types in Zed](../../formats/zson.md#23-primitive-values).
 ## Zeek NDJSON
 
 As an alternative to the default TSV format, there are two common ways that
-Zeek may instead generate logs in [NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON) format.
+Zeek may instead generate logs in [NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON) format.
 
 1. Using the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs)
    package (recommended for use with Zed)

--- a/versioned_docs/version-v1.12.0/formats/README.md
+++ b/versioned_docs/version-v1.12.0/formats/README.md
@@ -54,7 +54,7 @@ Each JSON value is self-describing in terms of its
 structure and types, though the JSON type system is limited.
 
 When a sequence of JSON objects is organized into a stream
-(perhaps [separated by newlines](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON))
+(perhaps [separated by newlines](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON))
 each value can take on any form.
 When all the values have the same form, the JSON sequence
 begins to look like a relational table, but the lack of a comprehensive type system,

--- a/versioned_docs/version-v1.12.0/formats/zjson.md
+++ b/versioned_docs/version-v1.12.0/formats/zjson.md
@@ -268,7 +268,7 @@ and an array of union of string, and float64 --- might have a value that looks l
 ## 3. Object Framing
 
 A ZJSON file is composed of ZJSON objects formatted as
-[newline delimited JSON (NDJSON)](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON).
+[newline delimited JSON (NDJSON)](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON).
 e.g., the [zq](../commands/zq.md) CLI command
 writes its ZJSON output as lines of NDJSON.
 

--- a/versioned_docs/version-v1.12.0/integrations/zeek/reading-zeek-log-formats.md
+++ b/versioned_docs/version-v1.12.0/integrations/zeek/reading-zeek-log-formats.md
@@ -79,7 +79,7 @@ equivalent [rich types in Zed](../../formats/zson.md#23-primitive-values).
 ## Zeek NDJSON
 
 As an alternative to the default TSV format, there are two common ways that
-Zeek may instead generate logs in [NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON) format.
+Zeek may instead generate logs in [NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#NDJSON) format.
 
 1. Using the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs)
    package (recommended for use with Zed)


### PR DESCRIPTION
https://github.com/brimdata/zed/pull/4954 fixed these links in the "latest" version of the docs, but the links in these older versioned docs are still there waiting to upset our link checkers. Fixing here so we can have green goodness again.