### PR TITLE
Fix Avro link in older doc revisions

### DIFF
--- a/versioned_docs/version-v1.10.0/commands/zq.md
+++ b/versioned_docs/version-v1.10.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.11.0/commands/zq.md
+++ b/versioned_docs/version-v1.11.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.12.0/commands/zq.md
+++ b/versioned_docs/version-v1.12.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.13.0/commands/zq.md
+++ b/versioned_docs/version-v1.13.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.14.0/commands/zq.md
+++ b/versioned_docs/version-v1.14.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.15.0/commands/zq.md
+++ b/versioned_docs/version-v1.15.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.16.0/commands/zq.md
+++ b/versioned_docs/version-v1.16.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.17.0/commands/zq.md
+++ b/versioned_docs/version-v1.17.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a number of [input](#input-formats) and [output](#output-formats) formats, but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.4.0/commands/zq.md
+++ b/versioned_docs/version-v1.4.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#2-input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.5.0/commands/zq.md
+++ b/versioned_docs/version-v1.5.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#2-input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.6.0/commands/zq.md
+++ b/versioned_docs/version-v1.6.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#2-input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.7.0/commands/zq.md
+++ b/versioned_docs/version-v1.7.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#2-input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.8.0/commands/zq.md
+++ b/versioned_docs/version-v1.8.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#2-input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.

--- a/versioned_docs/version-v1.9.0/commands/zq.md
+++ b/versioned_docs/version-v1.9.0/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a [number of formats](#input-formats) but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.


### PR DESCRIPTION
The change in https://github.com/brimdata/zed/pull/5244 fixed this link for the tip-of-`main` docs, but the broken link checker still gripes about that same link being in all the older tagged docs versions. This fixes the old ones too so we can be spared the CI failure notifications.