### PR TITLE
Change links to schools test data

### DIFF
--- a/versioned_docs/version-v1.10.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.10.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.10.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.10.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.10.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.10.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.11.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.11.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.11.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.11.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.11.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.11.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.12.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.12.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.12.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.12.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.12.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.12.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.13.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.13.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.13.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.13.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.13.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.13.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.14.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.14.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.14.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.14.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.14.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.14.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.15.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.15.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.15.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.15.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.15.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.15.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.16.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.16.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.16.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.16.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.16.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.16.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.17.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.17.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.17.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.17.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.17.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.17.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.18.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.18.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.18.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.18.0/tutorials/schools.md
@@ -93,7 +93,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.18.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.18.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.5.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.5.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.5.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.5.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.5.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.5.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.6.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.6.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.6.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.6.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.6.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.6.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.7.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.7.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.7.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.7.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.7.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.7.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.8.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.8.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.8.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.8.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.8.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.8.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started

--- a/versioned_docs/version-v1.9.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.9.0/tutorials/schools.md
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/main/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these

--- a/versioned_docs/version-v1.9.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.9.0/tutorials/schools.md
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.9.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.9.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/main/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started


### PR DESCRIPTION
This is a follow-on to https://github.com/brimdata/super/pull/5443.

While I doubt users are going to relive the magic of the schools tutorials in older tagged docs, I hate leaving behind dead links I know could easily be fixed. Therefore here I link to the last available home of the schools test data just in case some readers actually try to grab it.