### PR TITLE
Stop showing Next and add an announcement bar about SuperDB docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,6 +42,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
+          includeCurrentVersion: false,
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: ({docPath}) =>
             `https://github.com/brimdata/zed/edit/main/docs/${docPath}`,
@@ -57,6 +58,14 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: 'superdb_announce',
+        content:
+          'Zed is currently evolving into <a href="https://superdb.org/">SuperDB</a>. While still under construction, early <a href="https://superdb.org/docs/">SuperDB docs</a> are available.',
+        backgroundColor: '#F9DA46',
+        textColor: '#000',
+        isCloseable: false,
+      },
       image: "img/zed-social-image.jpg",
       metadata: [
         { name: "twitter:card", content: "summary" },


### PR DESCRIPTION
This is related to other PRs:

* https://github.com/brimdata/super/pull/5489
* https://github.com/brimdata/super/pull/5491
* https://github.com/brimdata/superdb-website/pull/6

In the time we've started the Zed->SuperDB transition, the "Next" selection in the versions drop-down on https://zed.brimdata.io/ has been showing the work-in-progress SuperDB docs. This has been as good a home as any for pointing early SuperDB users at relevant pages that speak to the new stuff. However, https://github.com/brimdata/super/pull/5489 is going to change the markdown in the Zed repo such that it'll no longer contain the Docusaurus-specific parts so it won't even be possible to publish the SuperDB docs here once that merges, and that's fine because https://github.com/brimdata/superdb-website/pull/6 will make it possible to publish them instead at their proper home as part of https://superdb.org/.

This PR does two things to make way for that transition:

1. The "Next" selection will no longer appear in the versions drop-down. Now the drop-down will only include GA releases up to v1.18.0 which was the final one known by the "Zed" name. [These Docusaurus config docs](https://docusaurus.io/docs/versioning#configuring-versioning-behavior) taught me about the `includeCurrentVersion` setting used to achieve this.

4. An [announcement bar](https://docusaurus.io/docs/api/themes/configuration#announcement-bar) is added to make users aware where the new SuperDB docs can be found.

We could potentially make other changes to be doubly sure users know about the transition (e.g., we could change what's on the initial https://zed.brimdata.io/ page, add some prominent text near the top of https://zed.brimdata.io/docs in the versioned v1.18.0 docs in this repo to mention SuperDB, etc.) but what's here should get us started.

I've published a build based on this branch to a personal staging site at https://spiffy-gnome-8f2834.netlify.app/ if anyone wants to give it a look. A screenshot that highlights the important differences:

![image](https://github.com/user-attachments/assets/297d3896-4624-41d5-bd04-97cfcfb2c233)

The one timing consideration of when this merges is that we'd only want to do it once https://superdb.org/docs is "live" to some degree, since the link in the announcement bar is pointing there early.
