### PR TITLE
Use a Hive hyperlink that's more stable

### DIFF
--- a/versioned_docs/version-v1.10.0/README.md
+++ b/versioned_docs/version-v1.10.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.11.0/README.md
+++ b/versioned_docs/version-v1.11.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.12.0/README.md
+++ b/versioned_docs/version-v1.12.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.13.0/README.md
+++ b/versioned_docs/version-v1.13.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.14.0/README.md
+++ b/versioned_docs/version-v1.14.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.15.0/README.md
+++ b/versioned_docs/version-v1.15.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.16.0/README.md
+++ b/versioned_docs/version-v1.16.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.17.0/README.md
+++ b/versioned_docs/version-v1.17.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.18.0/README.md
+++ b/versioned_docs/version-v1.18.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.5.0/README.md
+++ b/versioned_docs/version-v1.5.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.6.0/README.md
+++ b/versioned_docs/version-v1.6.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.7.0/README.md
+++ b/versioned_docs/version-v1.7.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.8.0/README.md
+++ b/versioned_docs/version-v1.8.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.

--- a/versioned_docs/version-v1.9.0/README.md
+++ b/versioned_docs/version-v1.9.0/README.md
@@ -87,7 +87,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A Zed lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.


### PR DESCRIPTION
This is a companion to https://github.com/brimdata/super/pull/5522 so the link checker here won't fuss when it checks the older tagged doc versions.
