### PR TITLE
Fix broken links in versioned docs

### DIFF
--- a/versioned_docs/version-v1.10.0/commands/zq.md
+++ b/versioned_docs/version-v1.10.0/commands/zq.md
@@ -546,7 +546,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.10.0/install.md
+++ b/versioned_docs/version-v1.10.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.10.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.10.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.10.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.10.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.10.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.10.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.10.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.10.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.11.0/commands/zq.md
+++ b/versioned_docs/version-v1.11.0/commands/zq.md
@@ -546,7 +546,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.11.0/install.md
+++ b/versioned_docs/version-v1.11.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.11.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.11.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.11.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.11.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.11.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.11.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.11.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.11.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.12.0/commands/zq.md
+++ b/versioned_docs/version-v1.12.0/commands/zq.md
@@ -547,7 +547,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.12.0/install.md
+++ b/versioned_docs/version-v1.12.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.12.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.12.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.12.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.12.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.12.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.12.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.12.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.12.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.13.0/commands/zq.md
+++ b/versioned_docs/version-v1.13.0/commands/zq.md
@@ -542,7 +542,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.13.0/install.md
+++ b/versioned_docs/version-v1.13.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.13.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.13.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.13.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.13.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.13.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.13.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.13.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.13.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.14.0/commands/zq.md
+++ b/versioned_docs/version-v1.14.0/commands/zq.md
@@ -542,7 +542,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.14.0/install.md
+++ b/versioned_docs/version-v1.14.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.14.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.14.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.14.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.14.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.14.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.14.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.14.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.14.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.15.0/commands/zq.md
+++ b/versioned_docs/version-v1.15.0/commands/zq.md
@@ -539,7 +539,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.15.0/formats/README.md
+++ b/versioned_docs/version-v1.15.0/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/versioned_docs/version-v1.15.0/formats/zjson.md
+++ b/versioned_docs/version-v1.15.0/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
+libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/versioned_docs/version-v1.15.0/install.md
+++ b/versioned_docs/version-v1.15.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.15.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.15.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.15.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.15.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.15.0/libraries/javascript.md
+++ b/versioned_docs/version-v1.15.0/libraries/javascript.md
@@ -5,7 +5,7 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 

--- a/versioned_docs/version-v1.15.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.15.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.15.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.15.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.16.0/commands/zq.md
+++ b/versioned_docs/version-v1.16.0/commands/zq.md
@@ -539,7 +539,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.16.0/formats/README.md
+++ b/versioned_docs/version-v1.16.0/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/versioned_docs/version-v1.16.0/formats/zjson.md
+++ b/versioned_docs/version-v1.16.0/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
+libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/versioned_docs/version-v1.16.0/install.md
+++ b/versioned_docs/version-v1.16.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.16.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.16.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.16.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.16.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.16.0/libraries/javascript.md
+++ b/versioned_docs/version-v1.16.0/libraries/javascript.md
@@ -5,7 +5,7 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 

--- a/versioned_docs/version-v1.16.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.16.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.16.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.16.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.17.0/commands/zq.md
+++ b/versioned_docs/version-v1.17.0/commands/zq.md
@@ -623,7 +623,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.17.0/formats/README.md
+++ b/versioned_docs/version-v1.17.0/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/versioned_docs/version-v1.17.0/formats/zjson.md
+++ b/versioned_docs/version-v1.17.0/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
+libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/versioned_docs/version-v1.17.0/install.md
+++ b/versioned_docs/version-v1.17.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.17.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.17.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.17.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.17.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.17.0/libraries/javascript.md
+++ b/versioned_docs/version-v1.17.0/libraries/javascript.md
@@ -5,7 +5,7 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 

--- a/versioned_docs/version-v1.17.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.17.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.17.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.17.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.18.0/commands/zq.md
+++ b/versioned_docs/version-v1.18.0/commands/zq.md
@@ -667,7 +667,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.18.0/formats/README.md
+++ b/versioned_docs/version-v1.18.0/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/versioned_docs/version-v1.18.0/formats/zjson.md
+++ b/versioned_docs/version-v1.18.0/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
+libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/versioned_docs/version-v1.18.0/install.md
+++ b/versioned_docs/version-v1.18.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.18.0/integrations/fluentd.md
+++ b/versioned_docs/version-v1.18.0/integrations/fluentd.md
@@ -59,7 +59,7 @@ After making these changes, Zeek was started by running
 
 ### Zed
 
-A binary [release package](https://github.com/brimdata/zed/releases) of Zed
+A binary [release package](https://github.com/brimdata/zed-archive/releases) of Zed
 executables compatible with our instance was downloaded and unpacked to a
 directory in our `$PATH`, then the [lake service](https://zed.brimdata.io/docs/commands/zed#serve)
 was started with a specified storage path.

--- a/versioned_docs/version-v1.18.0/integrations/fluentd.md
+++ b/versioned_docs/version-v1.18.0/integrations/fluentd.md
@@ -24,7 +24,7 @@ Linux 24.04. At the time this article was written, the following versions
 were used for the referenced software:
 
 * [Fluentd v1.17.0](https://github.com/fluent/fluentd/releases/tag/v1.17.0)
-* [Zed v1.17.0](https://github.com/brimdata/zed/releases/tag/v1.17.0)
+* [Zed v1.17.0](https://github.com/brimdata/zed-archive/releases/tag/v1.17.0)
 * [Zeek v6.2.1](https://github.com/zeek/zeek/releases/tag/v6.2.1)
 
 ### Zeek

--- a/versioned_docs/version-v1.18.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.18.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.18.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.18.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.18.0/libraries/javascript.md
+++ b/versioned_docs/version-v1.18.0/libraries/javascript.md
@@ -5,7 +5,7 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 

--- a/versioned_docs/version-v1.18.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.18.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -93,7 +93,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.18.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.18.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -93,7 +93,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.5.0/commands/zq.md
+++ b/versioned_docs/version-v1.5.0/commands/zq.md
@@ -547,7 +547,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.5.0/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed-archive/blob/v1.5.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.5.0/install.md
+++ b/versioned_docs/version-v1.5.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.5.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.5.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.5.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.5.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.6.0/commands/zq.md
+++ b/versioned_docs/version-v1.6.0/commands/zq.md
@@ -547,7 +547,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.6.0/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed-archive/blob/v1.6.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.6.0/install.md
+++ b/versioned_docs/version-v1.6.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.6.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.6.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.6.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.6.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.7.0/commands/zq.md
+++ b/versioned_docs/version-v1.7.0/commands/zq.md
@@ -547,7 +547,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.7.0/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed-archive/blob/v1.7.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.7.0/install.md
+++ b/versioned_docs/version-v1.7.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.7.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.7.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.7.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.7.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.7.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.7.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.7.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.7.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.8.0/commands/zq.md
+++ b/versioned_docs/version-v1.8.0/commands/zq.md
@@ -547,7 +547,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can
@@ -584,7 +584,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/v1.8.0/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed-archive/blob/v1.8.0/zeek/Data-Type-Compatibility.md)) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/versioned_docs/version-v1.8.0/install.md
+++ b/versioned_docs/version-v1.8.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.8.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.8.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.8.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.8.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.8.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.8.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.8.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.8.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.9.0/commands/zq.md
+++ b/versioned_docs/version-v1.9.0/commands/zq.md
@@ -546,7 +546,7 @@ is not particularly performant.  To this end, `zq` has its own lean and simple
 [JSON tokenizer](https://pkg.go.dev/github.com/brimdata/zed/pkg/jsonlexer),
 which performs quite well,
 and is
-[integrated tightly](https://github.com/brimdata/zed/blob/main/zio/jsonio/reader.go)
+[integrated tightly](https://github.com/brimdata/zed-archive/blob/main/zio/jsonio/reader.go)
 with Zed's internal data representation.
 Moreover, like `jq`,
 `zq`'s JSON parser does not require objects to be newline delimited and can

--- a/versioned_docs/version-v1.9.0/install.md
+++ b/versioned_docs/version-v1.9.0/install.md
@@ -31,7 +31,7 @@ Once installed, run a [quick test](#quick-tests).
 ## Binary Download
 
 We offer pre-built binaries for macOS, Windows and Linux for both x86 and arm
-architectures in the Zed [Github Release page](https://github.com/brimdata/zed/releases).
+architectures in the Zed [Github Release page](https://github.com/brimdata/zed-archive/releases).
 
 Each archive includes the build for `zq` and `zed`.
 

--- a/versioned_docs/version-v1.9.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.9.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
+[v1.6.0](https://github.com/brimdata/zed-archive/releases/tag/v1.6.0).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.9.0/integrations/zed-lake-auth.md
+++ b/versioned_docs/version-v1.9.0/integrations/zed-lake-auth.md
@@ -148,7 +148,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/zed/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 

--- a/versioned_docs/version-v1.9.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.9.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/schools.zson > schools.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/testscores.zson > testscores.zson
-curl https://raw.githubusercontent.com/brimdata/zed/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/zed/blob/v1.18.0/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
 
 ## 3. Searching
 

--- a/versioned_docs/version-v1.9.0/tutorials/schools.md
+++ b/versioned_docs/version-v1.9.0/tutorials/schools.md
@@ -7,7 +7,7 @@ sidebar_label: Schools Data
 
 > This document provides a beginner's overview of the Zed language
 using the [zq command](../commands/zq.md) and
-[real-world data](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md) relating to California schools
+[real-world data](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md) relating to California schools
 and test scores.
 
 ## 1. Getting Started
@@ -16,9 +16,9 @@ If you want to follow along by running the examples, simply
 [install zq](../install.md) and copy the
 data files used here into your working directory:
 ```
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/schools.zson > schools.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/testscores.zson > testscores.zson
-curl https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/webaddrs.zson > webaddrs.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/schools.zson > schools.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/testscores.zson > testscores.zson
+curl https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/webaddrs.zson > webaddrs.zson
 ```
 These files are all encoded in the human-readable [ZSON format](../formats/zson.md)
 so you can easily have a look at them.  ZSON is not optimized for speed but these
@@ -87,7 +87,7 @@ which emits
 Nothing too tricky here.  After a quick review of the shapes and types,
 you will notice they are just three relatively simple tables, which is no surprise
 since we obtained the original data from
-[SQLite database files](https://github.com/brimdata/super/blob/c1da204ac083642ef4b6aa1bec7e8565eb678730/testdata/edu/README.md).
+[SQLite database files](https://github.com/brimdata/zed-archive/blob/v1.18.0/testdata/edu/README.md).
 
 ## 3. Searching
 


### PR DESCRIPTION
In a recent [community Slack thread](https://super-db.slack.com/archives/CTT24051C/p1748251643167649) a user tried to follow some links in the older Zed-era docs that no longer work because we removed the old release tags to clear up the namespace for upcoming SuperDB-era tags. I'm fixing links here in hopes it may spare a future user from having to make a similar inquiry on Slack.

Since the Homebrew formulae are also referenced in the old docs, I've fixed those as well in a separate PR https://github.com/brimdata/homebrew-tap/pull/8.